### PR TITLE
deps: bump all fronted dependencies

### DIFF
--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "xterm-addon-attach": "0.9.0",
         "xterm-addon-fit": "0.8.0",
         "xterm-addon-web-links": "0.9.0",
-        "yaml": "2.3.4"
+        "yaml": "2.4.1"
       },
       "devDependencies": {
         "@fortawesome/fontawesome-free": "5.14.0",
@@ -17542,9 +17542,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
         "node": ">= 14"
       }

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@fortawesome/fontawesome-free": "5.14.0",
-        "autoprefixer": "10.4.14",
+        "autoprefixer": "10.4.19",
         "eslint-config-prettier": "9.1.0",
         "postcss-cli": "11.0.0",
         "prettier": "3.1.1",
@@ -4623,9 +4623,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.14",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+      "version": "10.4.19",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
       "funding": [
         {
           "type": "opencollective",
@@ -4634,12 +4634,16 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001464",
-        "fraction.js": "^4.2.0",
+        "browserslist": "^4.23.0",
+        "caniuse-lite": "^1.0.30001599",
+        "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -5111,9 +5115,9 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.21.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
-      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5129,10 +5133,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001489",
-        "electron-to-chromium": "^1.4.411",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5225,9 +5229,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001568",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001568.tgz",
-      "integrity": "sha512-vSUkH84HontZJ88MiNrOau1EBrCqEQYgkC5gIySiDlpsm8sGVrhU7Kx4V6h0tnqaHzIHZv08HlJIwPbL4XL9+A==",
+      "version": "1.0.30001609",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001609.tgz",
+      "integrity": "sha512-JFPQs34lHKx1B5t1EpQpWH4c+29zIyn/haGsbpfq3suuV9v56enjFt23zqijxGTMwy1p/4H2tjnQMY+p1WoAyA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6451,9 +6455,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.419",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.419.tgz",
-      "integrity": "sha512-jdie3RiEgygvDTyS2sgjq71B36q2cDSBfPlwzUyuOrfYTNoYWyBxxjGJV/HAu3A2hB0Y+HesvCVkVAFoCKwCSw=="
+      "version": "1.4.736",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.736.tgz",
+      "integrity": "sha512-Rer6wc3ynLelKNM4lOCg7/zPQj8tPOCB2hzD32PX9wd3hgRRi9MxEbmkFCokzcEhRVMiOVLjnL9ig9cefJ+6+Q=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -8000,15 +8004,15 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -12024,9 +12028,9 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -16473,9 +16477,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "yakd",
       "version": "0.0.0",
       "dependencies": {
-        "ace-builds": "1.32.1",
+        "ace-builds": "1.33.0",
         "ansi-to-html": "0.7.2",
         "dompurify": "3.0.6",
         "lodash": "4.17.21",
@@ -4279,9 +4279,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.32.1.tgz",
-      "integrity": "sha512-UuJLPoONqxbEaJTGff40fRTM0FNHRMe5iF3zuy6oWNnfSpkKe/Reqae3n9Cc49/yQ7Dmwdh5eT5fW8i4WxsvnA=="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.33.0.tgz",
+      "integrity": "sha512-PDvytkZNvAfuh+PaP5Oy3l3sBGd7xMk4NsB+4w/w1e3gjBqEOGeJwcX+wF/SB6mLtT3VfJLrhDNPT3eaCjtR3w=="
     },
     "node_modules/acorn": {
       "version": "7.4.0",

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "react": "18.2.0",
         "react-ace": "11.0.1",
         "react-dom": "18.2.0",
-        "react-redux": "9.0.4",
+        "react-redux": "9.1.0",
         "react-router-dom": "6.20.1",
         "react-scripts": "5.0.1",
         "react-virtualized": "9.22.5",
@@ -14471,9 +14471,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-redux": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.0.4.tgz",
-      "integrity": "sha512-9J1xh8sWO0vYq2sCxK2My/QO7MzUMRi3rpiILP/+tDr8krBHixC6JMM17fMK88+Oh3e4Ae6/sHIhNBgkUivwFA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.3",
         "use-sync-external-store": "^1.0.0"

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "autoprefixer": "10.4.19",
         "eslint-config-prettier": "9.1.0",
         "postcss-cli": "11.0.0",
-        "prettier": "3.1.1",
+        "prettier": "3.2.5",
         "tailwindcss": "3.3.6",
         "typeface-open-sans": "1.1.13"
       }
@@ -14043,9 +14043,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "lodash": "4.17.21",
         "prop-types": "15.8.1",
         "react": "18.2.0",
-        "react-ace": "10.1.0",
+        "react-ace": "11.0.1",
         "react-dom": "18.2.0",
         "react-redux": "9.0.4",
         "react-router-dom": "6.20.1",
@@ -14295,15 +14295,15 @@
       }
     },
     "node_modules/react-ace": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-10.1.0.tgz",
-      "integrity": "sha512-VkvUjZNhdYTuKOKQpMIZi7uzZZVgzCjM7cLYu6F64V0mejY8a2XTyPUIMszC6A4trbeMIHbK5fYFcT/wkP/8VA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-11.0.1.tgz",
+      "integrity": "sha512-ulk2851Fx2j59AAahZHTe7rmQ5bITW1xytskAt11F8dv3rPLtdwBXCyT2qSbRnJvOq8UpuAhWO4/JhKGqQBEDA==",
       "dependencies": {
-        "ace-builds": "^1.4.14",
+        "ace-builds": "^1.32.8",
         "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
         "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "react-router-dom": "6.20.1",
         "react-scripts": "5.0.1",
         "react-virtualized": "9.22.5",
-        "redux": "5.0.0",
+        "redux": "5.0.1",
         "xterm": "5.3.0",
         "xterm-addon-attach": "0.9.0",
         "xterm-addon-fit": "0.8.0",
@@ -14688,9 +14688,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.0.tgz",
-      "integrity": "sha512-blLIYmYetpZMET6Q6uCY7Jtl/Im5OBldy+vNPauA8vvsdqyt66oep4EUpAMWNHauTC6xa9JuRPhRB72rY82QGA=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/regenerate": {
       "version": "1.4.2",

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-config-prettier": "9.1.0",
         "postcss-cli": "11.0.0",
         "prettier": "3.2.5",
-        "tailwindcss": "3.3.6",
+        "tailwindcss": "3.4.3",
         "typeface-open-sans": "1.1.13"
       }
     },
@@ -15944,9 +15944,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.6.tgz",
-      "integrity": "sha512-AKjF7qbbLvLaPieoKeTjG1+FyNZT6KaJMJPFeQyLfIp7l82ggH1fbHJSsYIvnbTFQOlkh+gBYpyby5GT1LIdLw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
+      "integrity": "sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -15956,7 +15956,7 @@
         "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.19.1",
+        "jiti": "^1.21.0",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "react-ace": "11.0.1",
         "react-dom": "18.2.0",
         "react-redux": "9.1.0",
-        "react-router-dom": "6.20.1",
+        "react-router-dom": "6.22.3",
         "react-scripts": "5.0.1",
         "react-virtualized": "9.22.5",
         "redux": "5.0.1",
@@ -3188,9 +3188,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.1.tgz",
-      "integrity": "sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14505,11 +14505,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.20.1.tgz",
-      "integrity": "sha512-ccvLrB4QeT5DlaxSFFYi/KR8UMQ4fcD8zBcR71Zp1kaYTC5oJKYAp1cbavzGrogwxca+ubjkd7XjFZKBW8CxPA==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
       "dependencies": {
-        "@remix-run/router": "1.13.1"
+        "@remix-run/router": "1.15.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -14519,12 +14519,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.20.1.tgz",
-      "integrity": "sha512-npzfPWcxfQN35psS7rJgi/EW0Gx6EsNjfdJSAk73U/HqMEJZ2k/8puxfwHFgDQhBGmS3+sjnGbMdMSV45axPQw==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
       "dependencies": {
-        "@remix-run/router": "1.13.1",
-        "react-router": "6.20.1"
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "ace-builds": "1.33.0",
         "ansi-to-html": "0.7.2",
-        "dompurify": "3.0.6",
+        "dompurify": "3.1.0",
         "lodash": "4.17.21",
         "prop-types": "15.8.1",
         "react": "18.2.0",
@@ -6391,9 +6391,9 @@
       ]
     },
     "node_modules/dompurify": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
+      "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "ace-builds": "1.32.1",
+    "ace-builds": "1.33.0",
     "ansi-to-html": "0.7.2",
     "dompurify": "3.0.6",
     "lodash": "4.17.21",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -20,7 +20,7 @@
     "xterm-addon-attach": "0.9.0",
     "xterm-addon-fit": "0.8.0",
     "xterm-addon-web-links": "0.9.0",
-    "yaml": "2.3.4"
+    "yaml": "2.4.1"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "5.14.0",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -15,7 +15,7 @@
     "react-router-dom": "6.20.1",
     "react-scripts": "5.0.1",
     "react-virtualized": "9.22.5",
-    "redux": "5.0.0",
+    "redux": "5.0.1",
     "xterm": "5.3.0",
     "xterm-addon-attach": "0.9.0",
     "xterm-addon-fit": "0.8.0",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "ace-builds": "1.33.0",
     "ansi-to-html": "0.7.2",
-    "dompurify": "3.0.6",
+    "dompurify": "3.1.0",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
     "react": "18.2.0",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -9,7 +9,7 @@
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
     "react": "18.2.0",
-    "react-ace": "10.1.0",
+    "react-ace": "11.0.1",
     "react-dom": "18.2.0",
     "react-redux": "9.0.4",
     "react-router-dom": "6.20.1",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -12,7 +12,7 @@
     "react-ace": "11.0.1",
     "react-dom": "18.2.0",
     "react-redux": "9.1.0",
-    "react-router-dom": "6.20.1",
+    "react-router-dom": "6.22.3",
     "react-scripts": "5.0.1",
     "react-virtualized": "9.22.5",
     "redux": "5.0.1",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "5.14.0",
-    "autoprefixer": "10.4.14",
+    "autoprefixer": "10.4.19",
     "eslint-config-prettier": "9.1.0",
     "postcss-cli": "11.0.0",
     "prettier": "3.1.1",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -27,7 +27,7 @@
     "autoprefixer": "10.4.19",
     "eslint-config-prettier": "9.1.0",
     "postcss-cli": "11.0.0",
-    "prettier": "3.1.1",
+    "prettier": "3.2.5",
     "tailwindcss": "3.3.6",
     "typeface-open-sans": "1.1.13"
   },

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -28,7 +28,7 @@
     "eslint-config-prettier": "9.1.0",
     "postcss-cli": "11.0.0",
     "prettier": "3.2.5",
-    "tailwindcss": "3.3.6",
+    "tailwindcss": "3.4.3",
     "typeface-open-sans": "1.1.13"
   },
   "scripts": {

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -11,7 +11,7 @@
     "react": "18.2.0",
     "react-ace": "11.0.1",
     "react-dom": "18.2.0",
-    "react-redux": "9.0.4",
+    "react-redux": "9.1.0",
     "react-router-dom": "6.20.1",
     "react-scripts": "5.0.1",
     "react-virtualized": "9.22.5",


### PR DESCRIPTION
- deps(frontend): bump tailwindcss from 3.3.6 to 3.4.3
- deps(frontend): bump prettier from 3.1.1 to 3.2.5
- deps(frontend): bump autoprefixer from 10.4.14 to 10.4.19
- deps(frontend): bump yaml from 2.3.4 to 2.4.1
- deps(frontend): bump react-router-dom from 6.20.1 to 6.22.3
- deps(frontend): bump react-redux from 9.0.4 to 9.1.0
- deps(frontend): bump react-ace from 10.1.0 to 11.0.1
- deps(frontend): bump dompurify from 3.0.6 to 3.1.0
- deps(frontend): bump ace-builds from 1.32.1 to 1.33.0
- deps(frontend): bump redux from 5.0.0 to 5.0.1