### PR TITLE
chore(ci): publish container images to GitHub Container Registry

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,8 @@ jobs:
   publish-release-image:
     name: Publish YAKD Release
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -29,6 +31,9 @@ jobs:
       - name: Docker Hub Login
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: GitHub Container Registry Login
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build and Push
         run: |
           docker buildx build                                               \
@@ -36,5 +41,6 @@ jobs:
             --build-arg VERSION=${GITHUB_REF#refs/tags/v}                   \
             -f src/main/docker/Dockerfile.build                             \
             --tag marcnuri/yakd:${GITHUB_REF#refs/tags/v}                   \
+            --tag ghcr.io/manusa/yakd:${GITHUB_REF#refs/tags/v}             \
             --platform linux/amd64,linux/arm64                              \
             .

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -9,6 +9,8 @@ jobs:
   publish-snapshot-image:
     name: Publish YAKD Snapshot
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -29,6 +31,9 @@ jobs:
       - name: Docker Hub Login
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: GitHub Container Registry Login
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build and Push
         run: |
           docker buildx build                                               \
@@ -36,5 +41,6 @@ jobs:
             --build-arg VERSION=snapshot                                    \
             -f src/main/docker/Dockerfile.build                             \
             --tag marcnuri/yakd:snapshot                                    \
+            --tag ghcr.io/manusa/yakd:snapshot                              \
             --platform linux/amd64,linux/arm64                              \
             .


### PR DESCRIPTION
Fixes #134

In addition to Docker Hub, images are now also published to ghcr.io to help users avoid Docker Hub rate limits.

- Add GHCR login step using GITHUB_TOKEN
- Add ghcr.io/manusa/yakd tags to buildx push
- Add packages:write permission for GHCR access