### PR TITLE
test(watch): add unit tests for watch emitter components

### DIFF
--- a/src/test/java/com/marcnuri/yakd/fabric8/WatchableSubscriberTest.java
+++ b/src/test/java/com/marcnuri/yakd/fabric8/WatchableSubscriberTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2023 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created on 2025-12-13
+ */
+package com.marcnuri.yakd.fabric8;
+
+import com.marcnuri.yakd.watch.WatchEvent;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import jakarta.inject.Inject;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@WithKubernetesTestServer
+class WatchableSubscriberTest {
+
+  @Inject
+  KubernetesClient kubernetesClient;
+
+  @Nested
+  @DisplayName("WatchableSubscriber integration with Kubernetes API")
+  class IntegrationTests {
+
+    @Test
+    @DisplayName("should emit ADDED event with identity mapper")
+    void shouldEmitAddedEventWithIdentityMapper() {
+      // Given
+      var watchable = kubernetesClient.secrets().inNamespace(kubernetesClient.getNamespace());
+      var watchableSubscriber = WatchableSubscriber.subscriber(watchable);
+      var subscriber = AssertSubscriber.<WatchEvent<Secret>>create(Long.MAX_VALUE);
+      var closeException = new AtomicReference<WatcherException>();
+      Consumer<WatcherException> closeHandler = closeException::set;
+
+      Multi.createFrom().<WatchEvent<Secret>>emitter(emitter -> {
+        try (var ignored = watchableSubscriber.subscribe(closeHandler, emitter)) {
+          // When
+          kubernetesClient.secrets()
+            .resource(new SecretBuilder()
+              .withNewMetadata().withName("watchable-subscriber-test-added").endMetadata()
+              .addToStringData("key", "value")
+              .build())
+            .create();
+
+          // Then
+          Awaitility.await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> !subscriber.getItems().isEmpty() &&
+              subscriber.getItems().stream()
+                .anyMatch(e -> e.type() == Watcher.Action.ADDED &&
+                  "watchable-subscriber-test-added".equals(e.object().getMetadata().getName())));
+        } catch (Exception e) {
+          emitter.fail(e);
+        }
+      }).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream()
+          .anyMatch(e -> "watchable-subscriber-test-added".equals(e.object().getMetadata().getName())));
+
+      var addedEvent = subscriber.getItems().stream()
+        .filter(e -> e.type() == Watcher.Action.ADDED &&
+          "watchable-subscriber-test-added".equals(e.object().getMetadata().getName()))
+        .findFirst()
+        .orElseThrow();
+      assertThat(addedEvent.object()).isInstanceOf(Secret.class);
+    }
+
+    @Test
+    @DisplayName("should emit mapped event with custom mapper")
+    void shouldEmitMappedEventWithCustomMapper() {
+      // Given
+      var watchable = kubernetesClient.secrets().inNamespace(kubernetesClient.getNamespace());
+      var watchableSubscriber = WatchableSubscriber.subscriber(watchable, secret -> secret.getMetadata().getName());
+      var subscriber = AssertSubscriber.<WatchEvent<String>>create(Long.MAX_VALUE);
+      var closeException = new AtomicReference<WatcherException>();
+      Consumer<WatcherException> closeHandler = closeException::set;
+
+      Multi.createFrom().<WatchEvent<String>>emitter(emitter -> {
+        try (var ignored = watchableSubscriber.subscribe(closeHandler, emitter)) {
+          // When
+          kubernetesClient.secrets()
+            .resource(new SecretBuilder()
+              .withNewMetadata().withName("watchable-subscriber-test-mapped").endMetadata()
+              .build())
+            .create();
+
+          // Then
+          Awaitility.await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> !subscriber.getItems().isEmpty() &&
+              subscriber.getItems().stream()
+                .anyMatch(e -> "watchable-subscriber-test-mapped".equals(e.object())));
+        } catch (Exception e) {
+          emitter.fail(e);
+        }
+      }).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream()
+          .anyMatch(e -> "watchable-subscriber-test-mapped".equals(e.object())));
+
+      var addedEvent = subscriber.getItems().stream()
+        .filter(e -> "watchable-subscriber-test-mapped".equals(e.object()))
+        .findFirst()
+        .orElseThrow();
+      assertThat(addedEvent.type()).isEqualTo(Watcher.Action.ADDED);
+      assertThat(addedEvent.object()).isEqualTo("watchable-subscriber-test-mapped");
+    }
+
+    @Test
+    @DisplayName("should emit MODIFIED event when resource is updated")
+    void shouldEmitModifiedEvent() {
+      // Given
+      var created = kubernetesClient.secrets()
+        .resource(new SecretBuilder()
+          .withNewMetadata().withName("watchable-subscriber-test-modified").endMetadata()
+          .addToStringData("key", "original")
+          .build())
+        .create();
+
+      var watchable = kubernetesClient.secrets().inNamespace(kubernetesClient.getNamespace());
+      var watchableSubscriber = WatchableSubscriber.subscriber(watchable);
+      var subscriber = AssertSubscriber.<WatchEvent<Secret>>create(Long.MAX_VALUE);
+      var closeException = new AtomicReference<WatcherException>();
+      Consumer<WatcherException> closeHandler = closeException::set;
+
+      Multi.createFrom().<WatchEvent<Secret>>emitter(emitter -> {
+        try (var ignored = watchableSubscriber.subscribe(closeHandler, emitter)) {
+          // When
+          kubernetesClient.secrets()
+            .resource(new SecretBuilder(created)
+              .addToStringData("key", "updated")
+              .build())
+            .update();
+
+          // Then
+          Awaitility.await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> subscriber.getItems().stream()
+              .anyMatch(e -> e.type() == Watcher.Action.MODIFIED &&
+                "watchable-subscriber-test-modified".equals(e.object().getMetadata().getName())));
+        } catch (Exception e) {
+          emitter.fail(e);
+        }
+      }).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream()
+          .anyMatch(e -> e.type() == Watcher.Action.MODIFIED &&
+            "watchable-subscriber-test-modified".equals(e.object().getMetadata().getName())));
+    }
+
+    @Test
+    @DisplayName("should emit DELETED event when resource is deleted")
+    void shouldEmitDeletedEvent() {
+      // Given
+      kubernetesClient.secrets()
+        .resource(new SecretBuilder()
+          .withNewMetadata().withName("watchable-subscriber-test-deleted").endMetadata()
+          .build())
+        .create();
+
+      var watchable = kubernetesClient.secrets().inNamespace(kubernetesClient.getNamespace());
+      var watchableSubscriber = WatchableSubscriber.subscriber(watchable);
+      var subscriber = AssertSubscriber.<WatchEvent<Secret>>create(Long.MAX_VALUE);
+      var closeException = new AtomicReference<WatcherException>();
+      Consumer<WatcherException> closeHandler = closeException::set;
+
+      Multi.createFrom().<WatchEvent<Secret>>emitter(emitter -> {
+        try (var ignored = watchableSubscriber.subscribe(closeHandler, emitter)) {
+          // When
+          kubernetesClient.secrets().withName("watchable-subscriber-test-deleted").delete();
+
+          // Then
+          Awaitility.await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> subscriber.getItems().stream()
+              .anyMatch(e -> e.type() == Watcher.Action.DELETED &&
+                "watchable-subscriber-test-deleted".equals(e.object().getMetadata().getName())));
+        } catch (Exception e) {
+          emitter.fail(e);
+        }
+      }).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream()
+          .anyMatch(e -> e.type() == Watcher.Action.DELETED &&
+            "watchable-subscriber-test-deleted".equals(e.object().getMetadata().getName())));
+    }
+  }
+
+  @Nested
+  @DisplayName("Static factory methods")
+  class FactoryMethodTests {
+
+    @Test
+    @DisplayName("subscriber(watchable) should create subscriber with identity mapper")
+    void subscriberShouldCreateWithIdentityMapper() {
+      // Given
+      var watchable = kubernetesClient.secrets().inNamespace(kubernetesClient.getNamespace());
+
+      // When
+      var subscriber = WatchableSubscriber.subscriber(watchable);
+
+      // Then
+      assertThat(subscriber).isInstanceOf(WatchableSubscriber.class);
+    }
+
+    @Test
+    @DisplayName("subscriber(watchable, mapper) should create subscriber with custom mapper")
+    void subscriberWithMapperShouldCreateWithCustomMapper() {
+      // Given
+      var watchable = kubernetesClient.secrets().inNamespace(kubernetesClient.getNamespace());
+
+      // When
+      var subscriber = WatchableSubscriber.subscriber(watchable, secret -> secret.getMetadata().getName());
+
+      // Then
+      assertThat(subscriber).isInstanceOf(WatchableSubscriber.class);
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/fabric8/WatcherEmitterTest.java
+++ b/src/test/java/com/marcnuri/yakd/fabric8/WatcherEmitterTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2023 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created on 2025-12-13
+ */
+package com.marcnuri.yakd.fabric8;
+
+import com.marcnuri.yakd.watch.WatchEvent;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import io.fabric8.kubernetes.client.dsl.Watchable;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import jakarta.inject.Inject;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@WithKubernetesTestServer
+class WatcherEmitterTest {
+
+  @Inject
+  KubernetesClient kubernetesClient;
+
+  @Nested
+  @DisplayName("WatcherEmitter integration with Kubernetes API")
+  class IntegrationTests {
+
+    @Test
+    @DisplayName("should emit ADDED event when resource is created")
+    void shouldEmitAddedEvent() {
+      // Given
+      var watchable = kubernetesClient.configMaps().inNamespace(kubernetesClient.getNamespace());
+      var watcherEmitter = new WatcherEmitter<>(watchable);
+      var subscriber = AssertSubscriber.<WatchEvent<ConfigMap>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(watcherEmitter).subscribe().withSubscriber(subscriber);
+
+      // When
+      kubernetesClient.configMaps()
+        .resource(new ConfigMapBuilder()
+          .withNewMetadata().withName("watcher-emitter-test-added").endMetadata()
+          .addToData("key", "value")
+          .build())
+        .create();
+
+      // Then
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream()
+          .anyMatch(e -> e.type() == Watcher.Action.ADDED &&
+            "watcher-emitter-test-added".equals(e.object().getMetadata().getName())));
+
+      var addedEvent = subscriber.getItems().stream()
+        .filter(e -> e.type() == Watcher.Action.ADDED &&
+          "watcher-emitter-test-added".equals(e.object().getMetadata().getName()))
+        .findFirst()
+        .orElseThrow();
+      assertThat(addedEvent.object().getData()).containsEntry("key", "value");
+
+      // Cleanup
+      subscriber.cancel();
+    }
+
+    @Test
+    @DisplayName("should emit MODIFIED event when resource is updated")
+    void shouldEmitModifiedEvent() {
+      // Given
+      var created = kubernetesClient.configMaps()
+        .resource(new ConfigMapBuilder()
+          .withNewMetadata().withName("watcher-emitter-test-modified").endMetadata()
+          .addToData("key", "original")
+          .build())
+        .create();
+
+      var watchable = kubernetesClient.configMaps().inNamespace(kubernetesClient.getNamespace());
+      var watcherEmitter = new WatcherEmitter<>(watchable);
+      var subscriber = AssertSubscriber.<WatchEvent<ConfigMap>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(watcherEmitter).subscribe().withSubscriber(subscriber);
+
+      // When
+      kubernetesClient.configMaps()
+        .resource(new ConfigMapBuilder(created)
+          .addToData("key", "updated")
+          .build())
+        .update();
+
+      // Then
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream()
+          .anyMatch(e -> e.type() == Watcher.Action.MODIFIED &&
+            "watcher-emitter-test-modified".equals(e.object().getMetadata().getName()) &&
+            "updated".equals(e.object().getData().get("key"))));
+
+      // Cleanup
+      subscriber.cancel();
+    }
+
+    @Test
+    @DisplayName("should emit DELETED event when resource is deleted")
+    void shouldEmitDeletedEvent() {
+      // Given
+      kubernetesClient.configMaps()
+        .resource(new ConfigMapBuilder()
+          .withNewMetadata().withName("watcher-emitter-test-deleted").endMetadata()
+          .build())
+        .create();
+
+      var watchable = kubernetesClient.configMaps().inNamespace(kubernetesClient.getNamespace());
+      var watcherEmitter = new WatcherEmitter<>(watchable);
+      var subscriber = AssertSubscriber.<WatchEvent<ConfigMap>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(watcherEmitter).subscribe().withSubscriber(subscriber);
+
+      // When
+      kubernetesClient.configMaps().withName("watcher-emitter-test-deleted").delete();
+
+      // Then
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream()
+          .anyMatch(e -> e.type() == Watcher.Action.DELETED &&
+            "watcher-emitter-test-deleted".equals(e.object().getMetadata().getName())));
+
+      // Cleanup
+      subscriber.cancel();
+    }
+
+    @Test
+    @DisplayName("should emit multiple events in sequence")
+    void shouldEmitMultipleEvents() {
+      // Given
+      var watchable = kubernetesClient.configMaps().inNamespace(kubernetesClient.getNamespace());
+      var watcherEmitter = new WatcherEmitter<>(watchable);
+      var subscriber = AssertSubscriber.<WatchEvent<ConfigMap>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(watcherEmitter).subscribe().withSubscriber(subscriber);
+
+      // When - create multiple resources
+      kubernetesClient.configMaps()
+        .resource(new ConfigMapBuilder()
+          .withNewMetadata().withName("watcher-emitter-test-multi-1").endMetadata()
+          .build())
+        .create();
+      kubernetesClient.configMaps()
+        .resource(new ConfigMapBuilder()
+          .withNewMetadata().withName("watcher-emitter-test-multi-2").endMetadata()
+          .build())
+        .create();
+
+      // Then
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream()
+          .filter(e -> e.object().getMetadata().getName().startsWith("watcher-emitter-test-multi-"))
+          .count() >= 2);
+
+      assertThat(subscriber.getItems())
+        .extracting(e -> e.object().getMetadata().getName())
+        .contains("watcher-emitter-test-multi-1", "watcher-emitter-test-multi-2");
+
+      // Cleanup
+      subscriber.cancel();
+    }
+
+    @Test
+    @DisplayName("should close watch and stop emitting when cancelled")
+    void shouldStopOnCancel() {
+      // Given
+      var testWatchable = new TestWatchable();
+      var watcherEmitter = new WatcherEmitter<>(testWatchable);
+      var subscriber = AssertSubscriber.<WatchEvent<Pod>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(watcherEmitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> testWatchable.capturedWatcher.get() != null);
+
+      // When
+      subscriber.cancel();
+
+      // Then - verify watch was closed (state-based check, no waiting)
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(testWatchable.watchClosed::get);
+
+      // After watch is closed, emitting events should have no effect
+      final int countBeforeEmit = subscriber.getItems().size();
+      testWatchable.capturedWatcher.get().eventReceived(Watcher.Action.ADDED, null);
+
+      // Verify no new events were added (immediate state check)
+      assertThat(subscriber.getItems()).hasSize(countBeforeEmit);
+    }
+  }
+
+  @Nested
+  @DisplayName("WatchEventEmitter error handling")
+  class ErrorHandlingTests {
+
+    @Test
+    @DisplayName("should complete the emitter when onClose is called without exception")
+    void onCloseShouldCompleteEmitter() {
+      // Given
+      var testWatchable = new TestWatchable();
+      var watcherEmitter = new WatcherEmitter<>(testWatchable);
+      var subscriber = AssertSubscriber.<WatchEvent<Pod>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(watcherEmitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> testWatchable.capturedWatcher.get() != null);
+
+      // When
+      testWatchable.capturedWatcher.get().onClose();
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .untilAsserted(subscriber::assertCompleted);
+    }
+
+    @Test
+    @DisplayName("should fail the emitter when onClose is called with WatcherException")
+    void onCloseWithExceptionShouldFailEmitter() {
+      // Given
+      var testWatchable = new TestWatchable();
+      var watcherEmitter = new WatcherEmitter<>(testWatchable);
+      var subscriber = AssertSubscriber.<WatchEvent<Pod>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(watcherEmitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> testWatchable.capturedWatcher.get() != null);
+
+      // When
+      var exception = new WatcherException("Connection lost");
+      testWatchable.capturedWatcher.get().onClose(exception);
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .untilAsserted(() -> subscriber.assertFailedWith(WatcherException.class, "Connection lost"));
+    }
+
+    @Test
+    @DisplayName("should close watch when emitter is cancelled")
+    void shouldCloseWatchOnCancel() {
+      // Given
+      var testWatchable = new TestWatchable();
+      var watcherEmitter = new WatcherEmitter<>(testWatchable);
+      var subscriber = AssertSubscriber.<WatchEvent<Pod>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(watcherEmitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> testWatchable.capturedWatcher.get() != null);
+
+      // When
+      subscriber.cancel();
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(testWatchable.watchClosed::get);
+    }
+  }
+
+  /**
+   * Test implementation of Watchable for testing error handling scenarios
+   * that cannot be easily triggered with the Kubernetes mock server.
+   */
+  static class TestWatchable implements Watchable<Pod> {
+    final AtomicReference<Watcher<Pod>> capturedWatcher = new AtomicReference<>();
+    final AtomicBoolean watchClosed = new AtomicBoolean(false);
+
+    @Override
+    public Watch watch(ListOptions listOptions, Watcher<Pod> watcher) {
+      capturedWatcher.set(watcher);
+      return () -> watchClosed.set(true);
+    }
+
+    @Override
+    public Watch watch(String resourceVersion, Watcher<Pod> watcher) {
+      capturedWatcher.set(watcher);
+      return () -> watchClosed.set(true);
+    }
+
+    @Override
+    public Watch watch(Watcher<Pod> watcher) {
+      capturedWatcher.set(watcher);
+      return () -> watchClosed.set(true);
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/watch/SelfHealingWatchableEmitterTest.java
+++ b/src/test/java/com/marcnuri/yakd/watch/SelfHealingWatchableEmitterTest.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright 2023 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created on 2025-12-13
+ */
+package com.marcnuri.yakd.watch;
+
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SelfHealingWatchableEmitterTest {
+
+  private ScheduledExecutorService executorService;
+
+  @BeforeEach
+  void setUp() {
+    executorService = Executors.newScheduledThreadPool(4);
+  }
+
+  @AfterEach
+  void tearDown() {
+    executorService.shutdownNow();
+  }
+
+  @Nested
+  @DisplayName("SelfHealingWatchableEmitter.accept()")
+  class AcceptTests {
+
+    @Test
+    @DisplayName("should subscribe to all watchables")
+    void acceptShouldSubscribeToAllWatchables() {
+      // Given
+      var watchable1 = new TestWatchable();
+      var watchable2 = new TestWatchable();
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable1, watchable2));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      // When
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable1.subscribeCount.get() > 0 && watchable2.subscribeCount.get() > 0);
+      assertThat(watchable1.subscribeCount.get()).isGreaterThanOrEqualTo(1);
+      assertThat(watchable2.subscribeCount.get()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("should emit events from watchables")
+    void acceptShouldEmitEvents() {
+      // Given
+      var watchable = new TestWatchable();
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      // When
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() > 0);
+
+      watchable.emitEvent("test-event");
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> !subscriber.getItems().isEmpty());
+      assertThat(subscriber.getItems().get(0).type()).isEqualTo(Watcher.Action.ADDED);
+      assertThat(subscriber.getItems().get(0).object()).isEqualTo("test-event");
+    }
+  }
+
+  @Nested
+  @DisplayName("Self-healing behavior")
+  class SelfHealingTests {
+
+    @Test
+    @DisplayName("should emit ERROR event with RequestRestartError on watcher close")
+    void shouldEmitErrorOnWatcherClose() {
+      // Given
+      var watchable = new TestWatchable();
+      watchable.selfHealingDelay = Duration.ofMillis(50);
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() > 0);
+
+      // When
+      watchable.triggerClose(new WatcherException("Test exception"));
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> subscriber.getItems().stream().anyMatch(e -> e.type() == Watcher.Action.ERROR));
+
+      var errorEvent = subscriber.getItems().stream()
+        .filter(e -> e.type() == Watcher.Action.ERROR)
+        .findFirst()
+        .orElseThrow();
+      assertThat(errorEvent.object()).isInstanceOf(RequestRestartError.class);
+    }
+
+    @Test
+    @DisplayName("should resubscribe after watcher close with exception when retrySubscription is true")
+    void shouldResubscribeOnError() {
+      // Given
+      var watchable = new TestWatchable();
+      watchable.selfHealingDelay = Duration.ofMillis(50);
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() == 1);
+
+      // When
+      watchable.triggerClose(new WatcherException("Test exception"));
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() >= 2);
+    }
+
+    @Test
+    @DisplayName("should resubscribe after watcher close without exception when retrySubscription is true")
+    void shouldResubscribeOnCloseWithoutException() {
+      // Given
+      var watchable = new TestWatchable();
+      watchable.selfHealingDelay = Duration.ofMillis(50);
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() == 1);
+
+      // When
+      watchable.triggerClose(null);
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() >= 2);
+    }
+
+    @Test
+    @DisplayName("should not resubscribe when retrySubscription is false")
+    void shouldNotResubscribeWhenRetryFalse() {
+      // Given
+      var watchable = new TestWatchable();
+      watchable.retrySubscription = false;
+      watchable.selfHealingDelay = Duration.ofMillis(50);
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() == 1);
+
+      // When - triggerClose invokes handlers synchronously
+      watchable.triggerClose(new WatcherException("Test exception"));
+
+      // Then - When retrySubscription is false:
+      // 1. No ERROR event should be emitted (per implementation)
+      // 2. No resubscription should occur
+      // Since handlers run synchronously on triggerClose, we can assert immediately
+      assertThat(subscriber.getItems().stream().noneMatch(e -> e.type() == Watcher.Action.ERROR))
+        .as("No ERROR event should be emitted when retrySubscription is false")
+        .isTrue();
+      assertThat(watchable.subscribeCount.get())
+        .as("subscribeCount should still be 1 (no resubscription)")
+        .isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("Availability check")
+  class AvailabilityCheckTests {
+
+    @Test
+    @DisplayName("should skip subscription when availability check returns false")
+    void shouldSkipSubscriptionWhenNotAvailable() {
+      // Given
+      var watchable = new TestWatchable();
+      watchable.availabilityCheck = () -> false;
+      watchable.retrySubscriptionDelay = Duration.ofMillis(50);
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      // When
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      // Then - should retry after delay
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.availabilityCheckCount.get() >= 2);
+      assertThat(watchable.subscribeCount.get()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("should subscribe when availability check becomes true")
+    void shouldSubscribeWhenBecomesAvailable() {
+      // Given
+      var watchable = new TestWatchable();
+      watchable.availabilityCheck = () -> watchable.availabilityCheckCount.get() > 1;
+      watchable.retrySubscriptionDelay = Duration.ofMillis(50);
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      // When
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() >= 1);
+    }
+  }
+
+  @Nested
+  @DisplayName("Termination handling")
+  class TerminationTests {
+
+    @Test
+    @DisplayName("should close all active watches on termination")
+    void shouldCloseWatchesOnTermination() {
+      // Given
+      var watchable1 = new TestWatchable();
+      var watchable2 = new TestWatchable();
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable1, watchable2));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable1.subscribeCount.get() > 0 && watchable2.subscribeCount.get() > 0);
+
+      // When
+      subscriber.cancel();
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable1.closeCount.get() > 0 && watchable2.closeCount.get() > 0);
+    }
+
+    @Test
+    @DisplayName("should not resubscribe after emitter is cancelled")
+    void shouldNotResubscribeAfterCancel() {
+      // Given
+      var watchable = new TestWatchable();
+      watchable.selfHealingDelay = Duration.ofMillis(50);
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() == 1);
+
+      final int subscribeCountBefore = watchable.subscribeCount.get();
+
+      // When
+      subscriber.cancel();
+
+      // Then - wait for the watch to be closed (termination cleanup), then verify no resubscription
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.closeCount.get() > 0);
+
+      // State-based check: subscribeCount should be unchanged (no resubscription occurred)
+      assertThat(watchable.subscribeCount.get()).isEqualTo(subscribeCountBefore);
+    }
+  }
+
+  @Nested
+  @DisplayName("Duplicate subscription handling")
+  class DuplicateSubscriptionTests {
+
+    @Test
+    @DisplayName("should cancel previous subscription when resubscribing same watchable")
+    void shouldCancelPreviousSubscription() {
+      // Given
+      var watchable = new TestWatchable();
+      watchable.selfHealingDelay = Duration.ofMillis(50);
+      var emitter = new SelfHealingWatchableEmitter(executorService, List.of(watchable));
+      var subscriber = AssertSubscriber.<WatchEvent<?>>create(Long.MAX_VALUE);
+
+      Multi.createFrom().emitter(emitter).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() == 1);
+
+      // When - trigger close to force resubscription
+      watchable.triggerClose(null);
+
+      // Then
+      Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> watchable.subscribeCount.get() >= 2);
+
+      // Previous watch should have been closed before new subscription
+      assertThat(watchable.closeCount.get()).isGreaterThanOrEqualTo(1);
+    }
+  }
+
+  /**
+   * Test implementation of Watchable for unit testing.
+   */
+  static class TestWatchable implements Watchable<String> {
+    final AtomicInteger subscribeCount = new AtomicInteger(0);
+    final AtomicInteger closeCount = new AtomicInteger(0);
+    final AtomicInteger availabilityCheckCount = new AtomicInteger(0);
+    final List<Consumer<WatcherException>> closeHandlers = new CopyOnWriteArrayList<>();
+    final List<io.smallrye.mutiny.subscription.MultiEmitter<? super WatchEvent<String>>> emitters = new CopyOnWriteArrayList<>();
+
+    boolean retrySubscription = true;
+    Duration selfHealingDelay = Duration.ofSeconds(5);
+    Duration retrySubscriptionDelay = Duration.ofSeconds(30);
+    Supplier<Boolean> availabilityCheck = null;
+
+    @Override
+    public Subscriber<String> watch() {
+      return (close, emitter) -> {
+        subscribeCount.incrementAndGet();
+        closeHandlers.add(close);
+        emitters.add(emitter);
+        return closeCount::incrementAndGet;
+      };
+    }
+
+    @Override
+    public String getType() {
+      return "TestWatchable";
+    }
+
+    @Override
+    public Optional<Supplier<Boolean>> getAvailabilityCheckFunction() {
+      if (availabilityCheck == null) {
+        return Optional.empty();
+      }
+      return Optional.of(() -> {
+        availabilityCheckCount.incrementAndGet();
+        return availabilityCheck.get();
+      });
+    }
+
+    @Override
+    public boolean isRetrySubscription() {
+      return retrySubscription;
+    }
+
+    @Override
+    public Duration getSelfHealingDelay() {
+      return selfHealingDelay;
+    }
+
+    @Override
+    public Duration getRetrySubscriptionDelay() {
+      return retrySubscriptionDelay;
+    }
+
+    void emitEvent(String event) {
+      emitters.forEach(e -> e.emit(new WatchEvent<>(Watcher.Action.ADDED, event)));
+    }
+
+    void triggerClose(WatcherException exception) {
+      closeHandlers.forEach(h -> h.accept(exception));
+    }
+  }
+}


### PR DESCRIPTION
Fixes #137 

Add comprehensive unit tests for the self-healing watchable emitter and Fabric8 Kubernetes client watcher integration components:

- SelfHealingWatchableEmitter: subscription, self-healing, availability checks, termination handling, and duplicate subscription scenarios
- WatchableSubscriber: subscription, event emission with mapping, close handling, and closeable behavior
- WatcherEmitter: watch lifecycle, event emission, and termination