### PR TITLE
chore(deps): migrate xterm to @xterm/xterm

### DIFF
--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -8,6 +8,10 @@
       "name": "yakd",
       "version": "0.0.0",
       "dependencies": {
+        "@xterm/addon-attach": "0.11.0",
+        "@xterm/addon-fit": "0.10.0",
+        "@xterm/addon-web-links": "0.11.0",
+        "@xterm/xterm": "5.5.0",
         "ace-builds": "1.33.0",
         "ansi-to-html": "0.7.2",
         "dompurify": "3.1.0",
@@ -20,10 +24,6 @@
         "react-router-dom": "6.22.3",
         "react-virtualized": "9.22.6",
         "redux": "5.0.1",
-        "xterm": "5.3.0",
-        "xterm-addon-attach": "0.9.0",
-        "xterm-addon-fit": "0.8.0",
-        "xterm-addon-web-links": "0.9.0",
         "yaml": "2.4.5"
       },
       "devDependencies": {
@@ -1607,6 +1607,40 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@xterm/addon-attach": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-attach/-/addon-attach-0.11.0.tgz",
+      "integrity": "sha512-JboCN0QAY6ZLY/SSB/Zl2cQ5zW1Eh4X3fH7BnuR1NB7xGRhzbqU2Npmpiw/3zFlxDaU88vtKzok44JKi2L2V2Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz",
+      "integrity": "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ace-builds": {
       "version": "1.33.0",
@@ -7812,44 +7846,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/xterm-addon-attach": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-attach/-/xterm-addon-attach-0.9.0.tgz",
-      "integrity": "sha512-NykWWOsobVZPPK3P9eFkItrnBK9Lw0f94uey5zhqIVB1bhswdVBfl+uziEzSOhe2h0rT9wD0wOeAYsdSXeavPw==",
-      "deprecated": "This package is now deprecated. Move to @xterm/addon-attach instead.",
-      "license": "MIT",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
-    },
-    "node_modules/xterm-addon-fit": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
-      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
-      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
-      "license": "MIT",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
-    },
-    "node_modules/xterm-addon-web-links": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-web-links/-/xterm-addon-web-links-0.9.0.tgz",
-      "integrity": "sha512-LIzi4jBbPlrKMZF3ihoyqayWyTXAwGfu4yprz1aK2p71e9UKXN6RRzVONR0L+Zd+Ik5tPVI9bwp9e8fDTQh49Q==",
-      "deprecated": "This package is now deprecated. Move to @xterm/addon-web-links instead.",
-      "license": "MIT",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -16,10 +16,10 @@
     "react-router-dom": "6.22.3",
     "react-virtualized": "9.22.6",
     "redux": "5.0.1",
-    "xterm": "5.3.0",
-    "xterm-addon-attach": "0.9.0",
-    "xterm-addon-fit": "0.8.0",
-    "xterm-addon-web-links": "0.9.0",
+    "@xterm/xterm": "5.5.0",
+    "@xterm/addon-attach": "0.11.0",
+    "@xterm/addon-fit": "0.10.0",
+    "@xterm/addon-web-links": "0.11.0",
     "yaml": "2.4.5"
   },
   "devDependencies": {

--- a/src/main/frontend/src/pods/PodsExecPage.jsx
+++ b/src/main/frontend/src/pods/PodsExecPage.jsx
@@ -23,7 +23,7 @@ import {Card, Link} from '../components';
 import {DashboardPage} from '../dashboard';
 import {selectors, useExec} from './';
 
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 const mapStateToProps = ({pods}) => ({pods});
 

--- a/src/main/frontend/src/pods/useExec.js
+++ b/src/main/frontend/src/pods/useExec.js
@@ -15,10 +15,10 @@
  *
  */
 import {useEffect, useRef, useState} from 'react';
-import {Terminal} from 'xterm';
-import {AttachAddon} from 'xterm-addon-attach';
-import {FitAddon} from 'xterm-addon-fit';
-import {WebLinksAddon} from 'xterm-addon-web-links';
+import {Terminal} from '@xterm/xterm';
+import {AttachAddon} from '@xterm/addon-attach';
+import {FitAddon} from '@xterm/addon-fit';
+import {WebLinksAddon} from '@xterm/addon-web-links';
 import {api, useContainers} from './';
 
 const startTerminal = (ref, namespace, name, selectedContainer) => {


### PR DESCRIPTION
The xterm package is deprecated. Migrate to the new @xterm npm scope:
- xterm → @xterm/xterm 5.5.0
- xterm-addon-attach → @xterm/addon-attach 0.11.0
- xterm-addon-fit → @xterm/addon-fit 0.10.0
- xterm-addon-web-links → @xterm/addon-web-links 0.11.0

Closes #144