### PR TITLE
refactor: build pipeline composition and IT test structure

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -23,8 +23,8 @@ jobs:
       - name: Check license headers
         run: make license-check
 
-  verify:
-    name: Build and test
+  app-tests:
+    name: App tests (Java unit + Selenium UI)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,10 +40,10 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build and test
-        run: make test-backend
+      - name: Test the app
+        run: make test-app
 
-  test-frontend:
+  frontend-tests:
     name: Frontend tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -41,7 +41,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build and test
-        run: make verify
+        run: make test-backend
 
   test-frontend:
     name: Frontend tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ Use the `Makefile`. CI runs these exact targets (`.github/workflows/build-and-te
 |---------------------------------------|--------------------------|
 | Fast "still wired together" check     | `make quick-build`       |
 | Full build (frontend + backend)       | `make build`             |
-| Backend gate (CI's `verify` job)      | `make test-backend`      |
-| Full local CI mirror (all CI jobs)    | `make verify`            |
+| Test the Quarkus app (CI's `app-tests` job) | `make test-app`    |
+| Full local CI mirror — am I ready to push? | `make check`         |
 | Backend dev loop (hot reload, :8080)  | `make dev-backend`       |
 | Frontend dev loop (Vite, :3000)       | `make dev-frontend`      |
 | Deploy to local Minikube              | `make deploy-minikube`   |
@@ -156,15 +156,15 @@ The day-one knowledge. Each tied to a file path so you can verify it didn't drif
 
 ## CI reproduction
 
-`.github/workflows/build-and-test.yaml` runs three jobs in parallel (`license-check`, `verify`, `test-frontend`). Reproduce locally:
+`.github/workflows/build-and-test.yaml` runs three jobs in parallel (`license-check`, `app-tests`, `frontend-tests`). Reproduce locally:
 
 ```bash
-make test-backend    # mvn -Pbuild-frontend verify (frontend bundle + unit + ITs) — CI's `verify` job
-make test-frontend   # vitest — CI's `test-frontend` job
-make license-check   # .github/scripts/check-license-headers.sh — CI's `license-check` job
+make test-app        # Java unit + Selenium UI against the packaged app — CI's `app-tests` job
+make test-frontend   # Vitest — CI's `frontend-tests` job
+make license-check   # Apache header check — CI's `license-check` job
 ```
 
-Or one-shot via `make verify` — it chains the same three targets through Make composition (`verify: test license-check`, `test: test-backend test-frontend`).
+Or one-shot via `make check` — it chains the same three targets through Make composition (`check: test license-check`, `test: test-app test-frontend`).
 
 Release/snapshot pipelines (`publish-snapshot.yml`, `publish-release.yml`) build multi-arch images (`amd64` + `arm64`) and stitch them with `docker manifest create`. Required GitHub secrets: `DOCKER_USERNAME`, `DOCKER_PASSWORD` (Docker Hub); `GITHUB_TOKEN` is provided automatically (GHCR). Release tag `v1.2.3` → image tag `1.2.3` (strip via `${VERSION#v}`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Use the `Makefile`. CI runs these exact targets (`.github/workflows/build-and-te
 |---------------------------------------|--------------------------|
 | Fast "still wired together" check     | `make quick-build`       |
 | Full build (frontend + backend)       | `make build`             |
-| Full CI verification (= CI step 1)    | `make verify`            |
+| Backend gate (CI's `verify` job)      | `make test-backend`      |
+| Full local CI mirror (all CI jobs)    | `make verify`            |
 | Backend dev loop (hot reload, :8080)  | `make dev-backend`       |
 | Frontend dev loop (Vite, :3000)       | `make dev-frontend`      |
 | Deploy to local Minikube              | `make deploy-minikube`   |
@@ -140,11 +141,12 @@ The day-one knowledge. Each tied to a file path so you can verify it didn't drif
 - **`src/main/resources/application.properties:1`** — `quarkus.package.output-name=yakd` renames the legacy/fast-jar thin JAR. The runnable artifact for a JVM build lives in `target/quarkus-app/` (Quarkus 3.x fast-jar layout); the Docker image (`Dockerfile.build`) ships `target/yakd-runner` (native binary), not the JAR.
 - **`src/main/frontend/vite.config.js:37-42`** — Vite dev server proxies `/api/*` to `http://localhost:8080`. `make dev-backend` must be running alongside `make dev-frontend` or API calls return ECONNREFUSED.
 - **`src/main/frontend/vitest.config.js:26`** — global setup at `src/test-utils/vitest.setup.js` runs before every test. Anything jsdom-mutating (matchMedia stubs, etc.) lives there.
-- **`pom.xml:58-63`** — `kubernetes-model-gatewayapi` is excluded from `quarkus-kubernetes-client` (binary size / native-image trim). Don't re-add it without justification.
-- **`pom.xml:120-123`** — `src/main/frontend/build/` is mapped into the JAR at `targetPath=frontend`. A missing or stale `build/` ships zero (or stale) frontend assets silently — `make clean-frontend` before `make build` if you suspect this.
-- **`pom.xml:127-144`** — inside `<pluginManagement>`, both Surefire (127-135) and Failsafe (136-144) force `java.util.logging.manager=org.jboss.logmanager.LogManager` (declarations at lines 132 and 141; inherited by the failsafe execution at 161-170). Removing the system prop breaks every test (Quarkus needs JBoss LogManager).
+- **`pom.xml:62-67`** — `kubernetes-model-gatewayapi` is excluded from `quarkus-kubernetes-client` (binary size / native-image trim). Don't re-add it without justification.
+- **`pom.xml:124-127`** — `src/main/frontend/build/` is mapped into the JAR at `targetPath=frontend`. A missing or stale `build/` ships zero (or stale) frontend assets silently — `make clean-frontend` before `make build` if you suspect this.
+- **`pom.xml:131-149`** — inside `<pluginManagement>`, both Surefire (131-140) and Failsafe (141-149) force `java.util.logging.manager=org.jboss.logmanager.LogManager` (declarations at lines 137 and 146; inherited by the failsafe execution at 165-175). Removing the system prop breaks every test (Quarkus needs JBoss LogManager).
+- **`pom.xml:27-30,135`** — custom property `<surefire.skip>false</surefire.skip>` is wired into Surefire's `<skip>` parameter (line 135). This is what makes `-Dsurefire.skip=true` actually skip Surefire **without** also killing Failsafe — Surefire's built-in `skip` is bound to `maven.test.skip`, which would skip both. Don't strip the property or the binding during a pom cleanup; `make test-it` depends on it.
 - **`src/test/java/com/marcnuri/yakd/selenium/IntegrationTestProfile.java:30-34`** — sets `quarkus.kubernetes-client.devservices.enabled=false` in addition to the Selenium + Kubernetes test resources. Without it, ITs try to spin up a dev-services container and break in CI.
-- **`pom.xml:247-263`** — the `native` profile auto-activates on `-Dnative` and hardcodes JDK truststore path + `changeit` password into the GraalVM args. JDK relocations can break the native build.
+- **`pom.xml:252-268`** — the `native` profile auto-activates on `-Dnative` and hardcodes JDK truststore path + `changeit` password into the GraalVM args. JDK relocations can break the native build.
 - **`pom.xml:7,22-23`** — version flows through `${revision}` (default `0.0.0-SNAPSHOT`) and propagates into `container.image.tag`. Release pipeline passes `-Drevision=${VERSION#v}`.
 - **`src/test/java/com/marcnuri/yakd/selenium/SeleniumTestResource.java:42-55`** — uses `ChromeDriverService` directly with the `chrome` binary; **Chrome must be on PATH**. Headless mode (`--headless=new`) is on by default; flip with `@WithSelenium(headless = false)` when you need to see what's rendering.
 - **`.github/scripts/check-license-headers.sh:36`** — uses `git ls-files`, so brand-new files you forgot to `git add` are **silently skipped**. Always `git add` before `make license-check`. Globs cover `.java`, `.js`, `.jsx`, `.ts`, `.css` only.
@@ -154,13 +156,15 @@ The day-one knowledge. Each tied to a file path so you can verify it didn't drif
 
 ## CI reproduction
 
-`.github/workflows/build-and-test.yaml` runs exactly three steps. Reproduce locally:
+`.github/workflows/build-and-test.yaml` runs three jobs in parallel (`license-check`, `verify`, `test-frontend`). Reproduce locally:
 
 ```bash
-make verify          # mvn -Pbuild-frontend verify (the gate)
-make test-frontend   # vitest
-make license-check   # .github/scripts/check-license-headers.sh
+make test-backend    # mvn -Pbuild-frontend verify (frontend bundle + unit + ITs) — CI's `verify` job
+make test-frontend   # vitest — CI's `test-frontend` job
+make license-check   # .github/scripts/check-license-headers.sh — CI's `license-check` job
 ```
+
+Or one-shot via `make verify` — it chains the same three targets through Make composition (`verify: test license-check`, `test: test-backend test-frontend`).
 
 Release/snapshot pipelines (`publish-snapshot.yml`, `publish-release.yml`) build multi-arch images (`amd64` + `arm64`) and stitch them with `docker manifest create`. Required GitHub secrets: `DOCKER_USERNAME`, `DOCKER_PASSWORD` (Docker Hub); `GITHUB_TOKEN` is provided automatically (GHCR). Release tag `v1.2.3` → image tag `1.2.3` (strip via `${VERSION#v}`).
 

--- a/Makefile
+++ b/Makefile
@@ -42,23 +42,22 @@ native: ## Build native image (frontend + GraalVM native)
 ##@ Test
 
 .PHONY: test-backend
-test-backend: ## Run backend unit tests (no integration tests)
-	mvn test
+test-backend: ## Full backend gate (frontend bundle + unit + ITs via mvn verify)
+	mvn -Pbuild-frontend verify
 
 .PHONY: test-it
-test-it: ## Run Selenium integration tests (requires Chrome on PATH)
-	mvn failsafe:integration-test
+test-it: ## Run Selenium ITs (still goes through mvn verify package; set IT=Class[,Other] to filter)
+	mvn -Pbuild-frontend verify -Dsurefire.skip=true $(if $(IT),-Dit.test='$(IT)',)
 
 .PHONY: test-frontend
 test-frontend: ## Run frontend (Vitest) tests
 	cd $(FRONTEND_DIR) && npm test
 
 .PHONY: test
-test: test-backend test-it test-frontend ## Run all tests (backend + IT + frontend)
+test: test-backend test-frontend ## Run all tests (backend unit + ITs + frontend)
 
 .PHONY: verify
-verify: ## Run the full CI verification (mvn -Pbuild-frontend verify)
-	mvn -Pbuild-frontend verify
+verify: test license-check ## Full local CI mirror (all tests + license-check)
 
 ##@ Development
 

--- a/Makefile
+++ b/Makefile
@@ -41,23 +41,23 @@ native: ## Build native image (frontend + GraalVM native)
 
 ##@ Test
 
-.PHONY: test-backend
-test-backend: ## Full backend gate (frontend bundle + unit + ITs via mvn verify)
+.PHONY: test-app
+test-app: ## Test the Quarkus app (Java unit + Selenium UI against the packaged app)
 	mvn -Pbuild-frontend verify
 
 .PHONY: test-it
-test-it: ## Run Selenium ITs (still goes through mvn verify package; set IT=Class[,Other] to filter)
+test-it: ## Iteration helper: only the Selenium UI tests (set IT=Class[,Other] to filter)
 	mvn -Pbuild-frontend verify -Dsurefire.skip=true $(if $(IT),-Dit.test='$(IT)',)
 
 .PHONY: test-frontend
-test-frontend: ## Run frontend (Vitest) tests
+test-frontend: ## Frontend unit tests (Vitest — does not boot Quarkus or drive a browser)
 	cd $(FRONTEND_DIR) && npm test
 
 .PHONY: test
-test: test-backend test-frontend ## Run all tests (backend unit + ITs + frontend)
+test: test-app test-frontend ## Run all tests (test-app + test-frontend)
 
-.PHONY: verify
-verify: test license-check ## Full local CI mirror (all tests + license-check)
+.PHONY: check
+check: test license-check ## Full local CI mirror — "am I ready to push?" (test + license-check)
 
 ##@ Development
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
     <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
     <jkube.enricher.jkube-name.name>yakd</jkube.enricher.jkube-name.name>
     <k8s.namespace>default</k8s.namespace>
+    <!-- Surefire-only skip flag. Default false; override with -Dsurefire.skip=true
+         to skip unit tests without affecting Failsafe (ITs). Wired into the
+         Surefire <skip> parameter below. -->
+    <surefire.skip>false</surefire.skip>
   </properties>
 
   <dependencyManagement>
@@ -128,6 +132,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${version.surefire-maven-plugin}</version>
           <configuration>
+            <skip>${surefire.skip}</skip>
             <systemPropertyVariables>
               <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             </systemPropertyVariables>

--- a/src/test/java/com/marcnuri/yakd/HomeIT.java
+++ b/src/test/java/com/marcnuri/yakd/HomeIT.java
@@ -28,6 +28,8 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kubernetes.client.KubernetesServer;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -37,12 +39,12 @@ import org.openqa.selenium.support.ui.Wait;
 
 import java.net.URL;
 import java.time.Duration;
-import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
+@DisplayName("The home page")
 public class HomeIT {
 
   @KubernetesTestServer
@@ -73,27 +75,38 @@ public class HomeIT {
     wait.until(d -> d.findElement(By.cssSelector(".dashboard-page")).isDisplayed());
   }
 
-  @Test
-  void hasDocumentTitle() {
-    assertThat(driver.getTitle())
-      .isEqualTo("YAKD - Kubernetes Dashboard");
-  }
+  @Nested
+  @DisplayName("when the dashboard page is loaded")
+  class WhenDashboardPageIsLoaded {
 
-  @Test
-  void hasFooter() {
-    assertThat(driver.findElement(By.cssSelector(".dashboard-page footer")).getText())
-      .matches("Copyright © 2020-\\d{4} Marc Nuri - Licensed under the Apache License 2.0");
-  }
+    @Test
+    @DisplayName("sets the browser tab title to YAKD - Kubernetes Dashboard")
+    void setsBrowserTabTitle() {
+      assertThat(driver.getTitle())
+        .as("browser tab title")
+        .isEqualTo("YAKD - Kubernetes Dashboard");
+    }
 
-  @Test
-  void hasEventList() {
-    final By selector = By.cssSelector("[data-testid=list__events] [data-testid=list__events-row]");
-    final Wait<WebDriver> wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(5))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class);
-    wait.until(d -> d.findElement(selector).isDisplayed());
-    assertThat(driver.findElement(selector).getText())
-      .matches("^Pod\\na-pod-1\\nStarted Started container\\n.+");
+    @Test
+    @DisplayName("renders the Apache 2.0 copyright footer")
+    void rendersCopyrightFooter() {
+      assertThat(driver.findElement(By.cssSelector(".dashboard-page footer")).getText())
+        .as("dashboard footer text")
+        .matches("Copyright © 2020-\\d{4} Marc Nuri - Licensed under the Apache License 2.0");
+    }
+
+    @Test
+    @DisplayName("lists the seeded pod event in the events table")
+    void listsSeededPodEvent() {
+      final By selector = By.cssSelector("[data-testid=list__events] [data-testid=list__events-row]");
+      final Wait<WebDriver> wait = new FluentWait<>(driver)
+        .withTimeout(Duration.ofSeconds(5))
+        .pollingEvery(Duration.ofMillis(100))
+        .ignoring(NoSuchElementException.class);
+      wait.until(d -> d.findElement(selector).isDisplayed());
+      assertThat(driver.findElement(selector).getText())
+        .as("events table row text")
+        .matches("^Pod\\na-pod-1\\nStarted Started container\\n.+");
+    }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/pod/PodExecIT.java
+++ b/src/test/java/com/marcnuri/yakd/pod/PodExecIT.java
@@ -28,6 +28,8 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -43,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
+@DisplayName("The pod terminal page")
 public class PodExecIT {
 
   private static final String POD_UID = "test-pod-uid-12345";
@@ -100,38 +103,51 @@ public class PodExecIT {
     driver.switchTo().window(driver.getWindowHandles().iterator().next());
   }
 
-  @Test
-  void displaysTerminalPageWithPodName() {
-    // Verify page title includes Terminal and pod name
-    assertThat(driver.findElement(By.cssSelector(".dashboard-page")).getText())
-      .contains("Terminal")
-      .contains(POD_NAME);
-  }
+  @Nested
+  @DisplayName("when opened for a running pod")
+  class WhenOpenedForRunningPod {
 
-  @Test
-  void terminalComponentRenders() {
-    // Wait for xterm terminal to render inside the test container
-    wait.until(d -> !d.findElements(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm")).isEmpty());
+    @Test
+    @DisplayName("includes 'Terminal' and the pod name in the page header")
+    void displaysTerminalPageWithPodName() {
+      assertThat(driver.findElement(By.cssSelector(".dashboard-page")).getText())
+        .as("dashboard page header text")
+        .contains("Terminal")
+        .contains(POD_NAME);
+    }
 
-    // Verify xterm container is present and displayed
-    assertThat(driver.findElement(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm")).isDisplayed())
-      .isTrue();
+    @Test
+    @DisplayName("renders an initialized xterm.js terminal component")
+    void terminalComponentRenders() {
+      // Wait for xterm terminal to render inside the test container
+      wait.until(d -> !d.findElements(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm")).isEmpty());
 
-    // Verify xterm creates a screen element (confirms terminal is initialized)
-    wait.until(d -> !d.findElements(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm-screen")).isEmpty());
-    assertThat(driver.findElement(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm-screen")).isDisplayed())
-      .isTrue();
+      // Verify xterm container is present and displayed
+      assertThat(driver.findElement(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm")).isDisplayed())
+        .as("xterm container is visible")
+        .isTrue();
 
-    // Verify xterm helper textarea is present (used for clipboard and input)
-    // This confirms the terminal is fully initialized and interactive
-    assertThat(driver.findElements(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm-helper-textarea")))
-      .isNotEmpty();
-  }
+      // Verify xterm creates a screen element (confirms terminal is initialized)
+      wait.until(d -> !d.findElements(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm-screen")).isEmpty());
+      assertThat(driver.findElement(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm-screen")).isDisplayed())
+        .as("xterm screen element is visible")
+        .isTrue();
 
-  @Test
-  void containerDropdownDisplaysContainerName() {
-    // Verify the container dropdown shows the container name
-    final var dropdown = driver.findElement(By.cssSelector("[data-testid='container-dropdown']"));
-    assertThat(dropdown.getText()).contains(CONTAINER_NAME);
+      // Verify xterm helper textarea is present (used for clipboard and input)
+      // This confirms the terminal is fully initialized and interactive
+      assertThat(driver.findElements(By.cssSelector("[data-testid='pod-exec__terminal'] .xterm-helper-textarea")))
+        .as("xterm helper textarea (clipboard/input) is present")
+        .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("the container dropdown shows the container's name")
+    void containerDropdownDisplaysContainerName() {
+      // Verify the container dropdown shows the container name
+      final var dropdown = driver.findElement(By.cssSelector("[data-testid='container-dropdown']"));
+      assertThat(dropdown.getText())
+        .as("container dropdown label")
+        .contains(CONTAINER_NAME);
+    }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/pod/PodLogsIT.java
+++ b/src/test/java/com/marcnuri/yakd/pod/PodLogsIT.java
@@ -28,6 +28,8 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -43,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
+@DisplayName("The pod logs page")
 public class PodLogsIT {
 
   private static final String POD_UID = "test-pod-uid-logs";
@@ -113,27 +116,40 @@ public class PodLogsIT {
     driver.switchTo().window(driver.getWindowHandles().iterator().next());
   }
 
-  @Test
-  void displaysLogsPageWithPodName() {
-    assertThat(driver.findElement(By.cssSelector(".dashboard-page")).getText())
-      .contains("Logs")
-      .contains(POD_NAME);
+  @Nested
+  @DisplayName("when first opened for a 2-container pod")
+  class WhenFirstOpened {
+
+    @Test
+    @DisplayName("includes 'Logs' and the pod name in the page header")
+    void displaysLogsPageWithPodName() {
+      assertThat(driver.findElement(By.cssSelector(".dashboard-page")).getText())
+        .as("dashboard page header text")
+        .contains("Logs")
+        .contains(POD_NAME);
+    }
+
+    @Test
+    @DisplayName("streams the first container's logs into the content area")
+    void displaysFirstContainerLogs() {
+      wait.until(d -> d.findElement(By.cssSelector(".pods-logs-page [data-testid='pod-logs__content']")).getText().contains("Hello from container 1 logs!"));
+      assertThat(driver.findElement(By.cssSelector(".pods-logs-page [data-testid='pod-logs__content']")).getText())
+        .as("pod logs content")
+        .contains("Hello from container 1 logs!");
+    }
+
+    @Test
+    @DisplayName("the container dropdown shows the first container's name")
+    void containerDropdownDisplaysFirstContainerName() {
+      final var dropdown = driver.findElement(By.cssSelector("[data-testid='container-dropdown']"));
+      assertThat(dropdown.getText())
+        .as("container dropdown label")
+        .contains("container-1");
+    }
   }
 
   @Test
-  void displaysFirstContainerLogs() {
-    wait.until(d -> d.findElement(By.cssSelector(".pods-logs-page [data-testid='pod-logs__content']")).getText().contains("Hello from container 1 logs!"));
-    assertThat(driver.findElement(By.cssSelector(".pods-logs-page [data-testid='pod-logs__content']")).getText())
-      .contains("Hello from container 1 logs!");
-  }
-
-  @Test
-  void containerDropdownDisplaysFirstContainerName() {
-    final var dropdown = driver.findElement(By.cssSelector("[data-testid='container-dropdown']"));
-    assertThat(dropdown.getText()).contains("container-1");
-  }
-
-  @Test
+  @DisplayName("switching to container-2 via the dropdown replaces the visible logs with the second container's stream")
   void switchingContainerDisplaysCorrectLogs() {
     wait.until(d -> d.findElement(By.cssSelector(".pods-logs-page [data-testid='pod-logs__content']")).getText().contains("Hello from container 1 logs!"));
 
@@ -143,6 +159,7 @@ public class PodLogsIT {
 
     wait.until(d -> d.findElement(By.cssSelector(".pods-logs-page [data-testid='pod-logs__content']")).getText().contains("Hello from container 2 logs!"));
     assertThat(driver.findElement(By.cssSelector(".pods-logs-page [data-testid='pod-logs__content']")).getText())
+      .as("pod logs content after container switch")
       .contains("Hello from container 2 logs!");
   }
 }


### PR DESCRIPTION
## Summary

Three commits — keep separate for rebase-merge, or squash if you prefer.

### 1. Compose make targets and align CI (`refactor(build):`, commit 1)

- `make` targets now compose via dependency lists, not chained shells:
  - `check` = `test` + `license-check`
  - `test` = `test-app` + `test-frontend`
- One Maven invocation per run (no more double-Surefire startup that the previous `test-backend test-it test-frontend` chain caused).
- `test-app` = `mvn -Pbuild-frontend verify` — tests the Quarkus app end-to-end (Java unit + Selenium UI against the packaged app with bundled frontend).
- `test-it` is a standalone iteration helper for Selenium-only runs with an `IT=Class[,Other]` filter; uses `-Dsurefire.skip=true`.
- `pom.xml` wires a custom `<surefire.skip>` property into Surefire's `<skip>` parameter so `-Dsurefire.skip=true` actually skips only Surefire. The built-in `skip` is bound to `maven.test.skip`, which would also kill Failsafe — that is why the custom property is needed.
- CI calls leaf targets (`make test-app`, `make test-frontend`, `make license-check`) as parallel jobs so per-step wall-clock stays visible.
- `AGENTS.md`: canonical commands + CI reproduction updated; new gotcha covers the `<surefire.skip>` wiring; drifted `pom.xml:` line refs refreshed.

### 2. IT test structure (`test(it):`, commit 2)

3 Selenium IT classes get `@Nested` + `@DisplayName` so Failsafe output reads as behavior sentences ("The pod logs page › when first opened for a 2-container pod › includes 'Logs' and the pod name in the page header") instead of HTTP-verb method names. `.as(...)` descriptions added to assertions to surface behavior context on failure. No behavior change — same setup, same assertions; structure and naming only.

### 3. Declarative target and CI job names (`refactor(build):`, commit 3)

Rename Make targets and CI job IDs to describe *what they test* instead of which Maven phase runs underneath:

- `test-backend` → `test-app`. The old name read as "backend unit tests" but the target drives Selenium against the rendered UI too.
- `verify` → `check`. Avoids overloading Maven's `verify` phase name with the "full local CI mirror" semantic.
- CI job `verify` → `app-tests`; `test-frontend` → `frontend-tests`.
- `test-it` keeps its short name; help text clarifies it is an iteration helper for the Selenium subset of `test-app`.

## Test plan

- [x] \`make test-it IT=HomeIT,PodLogsIT,PodExecIT\` → 10/10 green
- [x] \`make check\` → all checks (Java unit + Selenium UI + Vitest + license) green locally
- [x] \`mvn test -Dtest=StandardStreamTest\` (default path, no \`-Dsurefire.skip\`) → Surefire still runs (verifies the pom default is \`false\`)
- [x] \`make help\` lists targets with correct descriptions