### PR TITLE
test: stabilize watch tests against leftover-resource flake

### DIFF
--- a/src/test/java/com/marcnuri/yakd/CronJobsTest.java
+++ b/src/test/java/com/marcnuri/yakd/CronJobsTest.java
@@ -21,11 +21,13 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.batch.v1.CronJobBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 import jakarta.inject.Inject;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -50,6 +52,13 @@ class CronJobsTest {
   KubernetesClient kubernetesClient;
   @TestHTTPResource
   URL url;
+
+  @AfterEach
+  void cleanUp() {
+    final var namespace = kubernetesClient.getConfiguration().getNamespace();
+    kubernetesClient.batch().v1().cronjobs().inNamespace(namespace).delete();
+    kubernetesClient.batch().v1().jobs().inNamespace(namespace).delete();
+  }
 
   @Test
   @DisplayName("DELETE /api/v1/cronjobs/{namespace}/{name} - Should delete the Cron Job")
@@ -128,8 +137,9 @@ class CronJobsTest {
       // When
       Awaitility.await()
         .atMost(10, TimeUnit.SECONDS)
-        .until(() -> watch.events().stream()
-          .anyMatch(watchEvent -> ((Map<String, ?>)watchEvent.object().get("metadata")).get("name").equals("to-watch")));
+        .until(() -> watch.events().stream().anyMatch(watchEvent ->
+          Watcher.Action.ADDED.equals(watchEvent.type())
+            && "to-watch".equals(((Map<String, ?>) watchEvent.object().get("metadata")).get("name"))));
       // Then
       assertThat(watch.events())
         .extracting("object.kind", "object.metadata.name")

--- a/src/test/java/com/marcnuri/yakd/NamespaceTest.java
+++ b/src/test/java/com/marcnuri/yakd/NamespaceTest.java
@@ -25,11 +25,13 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 import jakarta.inject.Inject;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -45,6 +47,11 @@ class NamespaceTest {
   KubernetesClient kubernetesClient;
   @TestHTTPResource
   URL url;
+
+  @AfterEach
+  void cleanUp() {
+    kubernetesClient.namespaces().delete();
+  }
 
   @Test
   @DisplayName("GET /api/v1/namespaces - Should list namespaces")
@@ -85,7 +92,9 @@ class NamespaceTest {
       // When
       Awaitility.await()
         .atMost(10, TimeUnit.SECONDS)
-        .until(() -> watch.events().stream().anyMatch(watchEvent -> Watcher.Action.ADDED.equals(watchEvent.type())));
+        .until(() -> watch.events().stream().anyMatch(watchEvent ->
+          Watcher.Action.ADDED.equals(watchEvent.type())
+            && "to-watch".equals(((Map<String, ?>) watchEvent.object().get("metadata")).get("name"))));
       // Then
       assertThat(watch.events())
         .extracting("object.kind", "object.metadata.name")

--- a/src/test/java/com/marcnuri/yakd/NodeTest.java
+++ b/src/test/java/com/marcnuri/yakd/NodeTest.java
@@ -26,11 +26,13 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 import jakarta.inject.Inject;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.given;
@@ -46,6 +48,11 @@ class NodeTest {
   KubernetesClient kubernetesClient;
   @TestHTTPResource
   URL url;
+
+  @AfterEach
+  void cleanUp() {
+    kubernetesClient.nodes().delete();
+  }
 
   @Test
   @DisplayName("PUT /api/v1/nodes/{name} - Should update the node")
@@ -73,7 +80,9 @@ class NodeTest {
       // When
       Awaitility.await()
         .atMost(10, TimeUnit.SECONDS)
-        .until(() -> watch.events().stream().anyMatch(watchEvent -> Watcher.Action.ADDED.equals(watchEvent.type())));
+        .until(() -> watch.events().stream().anyMatch(watchEvent ->
+          Watcher.Action.ADDED.equals(watchEvent.type())
+            && "to-watch".equals(((Map<String, ?>) watchEvent.object().get("metadata")).get("name"))));
       // Then
       assertThat(watch.events())
         .extracting("object.kind", "object.metadata.name")

--- a/src/test/java/com/marcnuri/yakd/ServiceTest.java
+++ b/src/test/java/com/marcnuri/yakd/ServiceTest.java
@@ -26,11 +26,13 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 import jakarta.inject.Inject;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -49,6 +51,11 @@ class ServiceTest {
   KubernetesClient kubernetesClient;
   @TestHTTPResource
   URL url;
+
+  @AfterEach
+  void cleanUp() {
+    kubernetesClient.services().inNamespace(kubernetesClient.getConfiguration().getNamespace()).delete();
+  }
 
   @Test
   @DisplayName("DELETE /api/v1/services/{namespace}/{name} - Should delete the service")
@@ -89,7 +96,9 @@ class ServiceTest {
       // When
       Awaitility.await()
         .atMost(10, TimeUnit.SECONDS)
-        .until(() -> watch.events().stream().anyMatch(watchEvent -> Watcher.Action.ADDED.equals(watchEvent.type())));
+        .until(() -> watch.events().stream().anyMatch(watchEvent ->
+          Watcher.Action.ADDED.equals(watchEvent.type())
+            && "to-watch".equals(((Map<String, ?>) watchEvent.object().get("metadata")).get("name"))));
       // Then
       assertThat(watch.events())
         .extracting("object.kind", "object.metadata.name")

--- a/src/test/java/com/marcnuri/yakd/pod/PodTest.java
+++ b/src/test/java/com/marcnuri/yakd/pod/PodTest.java
@@ -26,11 +26,13 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 import jakarta.inject.Inject;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -49,6 +51,11 @@ class PodTest {
   KubernetesClient kubernetesClient;
   @TestHTTPResource
   URL url;
+
+  @AfterEach
+  void cleanUp() {
+    kubernetesClient.pods().inNamespace(kubernetesClient.getConfiguration().getNamespace()).delete();
+  }
 
   @Test
   @DisplayName("GET /api/v1/pods/{namespace}/{name} - Should get the pod")
@@ -101,7 +108,9 @@ class PodTest {
       // When
       Awaitility.await()
         .atMost(10, TimeUnit.SECONDS)
-        .until(() -> watch.events().stream().anyMatch(watchEvent -> Watcher.Action.ADDED.equals(watchEvent.type())));
+        .until(() -> watch.events().stream().anyMatch(watchEvent ->
+          Watcher.Action.ADDED.equals(watchEvent.type())
+            && "to-watch".equals(((Map<String, ?>) watchEvent.object().get("metadata")).get("name"))));
       // Then
       assertThat(watch.events())
         .extracting("object.kind", "object.metadata.name")


### PR DESCRIPTION
## Problem

The `watch` integration tests waited for *any* `ADDED` event:

`.until(() -> watch.events().stream().anyMatch(e -> Watcher.Action.ADDED.equals(e.type())))`

`@WithKubernetesTestServer` shares one CRUD mock store across all test
methods in a class. A resource created by a sibling method and never
deleted (e.g. `to-update` from `update()`) replays as `ADDED` during the
watch's initial sync, satisfying the loose await before the test's own
`to-watch` resource is observed. The assertion then runs too early and
sees only the leftover — an order-dependent flake.

## Fix

For each affected `watch` test:
- Tighten the await to the specific `ADDED` event for `"to-watch"`.
- Add an `@AfterEach` that deletes the class's managed resources,
  isolating each test method.

Applied to `ServiceTest`, `NamespaceTest`, `NodeTest` and `PodTest`.
`CronJobsTest` already matched on name; its await is brought in line with
the same `ADDED`-guarded form (also closing a latent NPE if an `ERROR`
event ever enters the stream) and given the same `@AfterEach` cleanup.

## Verification

- Deterministic reproduction of the original failure in forced
  `update`→`watch` order, then green after the fix.
- `ServiceTest` passes 50/50 consecutive runs in the worst-case method order.
- All five watch test classes pass together (17 tests).

Refs manusa/com.marcnuri.automated-tasks#1837