### PR TITLE
test: harden PodExecEndpointTest groups off the shared timed close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,28 @@ make license-check   # Apache header check — CI's `license-check` job
 
 Or one-shot via `make check` — it chains the same three targets through Make composition (`check: test license-check`, `test: test-app test-frontend`).
 
+### Reproducing contention/timing flakes
+
+Some `@QuarkusTest` tests (notably the WebSocket suites like `PodExecEndpointTest`) only flake under CPU contention. **Reproduce contention with a CPU-limited Docker container — NOT `yes`/CPU-burner loops on the host.** Burner loops saturate the developer's machine and make it unusable; a `--cpus`-constrained container reproduces the same ~2-vCPU pressure (the documented root cause for this flake class) without touching host responsiveness. Run the loop offline against the host `~/.m2`:
+
+```bash
+mkdir -p /tmp/flake-logs
+docker run --rm --cpus=2 \
+  -e HOME=/tmp \
+  -v "$PWD":/work -w /work \
+  -v "$HOME/.m2":/m2 \
+  -v /tmp/flake-logs:/logs \
+  --user "$(id -u):$(id -g)" --entrypoint bash \
+  maven:3.9.9-eclipse-temurin-21 -c '
+    for i in $(seq 1 50); do
+      mvn -o -s /m2/settings.xml -Dmaven.repo.local=/m2/repository \
+        clean test -Dtest=PodExecEndpointTest -Dquarkus.build.skip=true > /logs/run-$i.log 2>&1 \
+        && echo "run $i PASS" || echo "run $i FAIL"
+    done'
+```
+
+Gotchas (each will silently waste a loop if missed): `~/.m2` mounts to `/m2`, so the repo is `/m2/repository` — point `-Dmaven.repo.local` there, not `/m2`. Pass `-s /m2/settings.xml` so offline marker-matching (`_remote.repositories` repo ids — the project resolves some artifacts from redhat repos) succeeds. `--entrypoint bash` skips the image's `mvn-entrypoint.sh`, which fails trying to `mkdir /root` under `--user`. **Use `clean test` every iteration, not incremental `test`** — re-running `mvn test` in a loop over a shared `target/` progressively corrupts the Quarkus app-model cache (manifests after ~20 iterations as `ClassNotFoundException` / `404 Not Found` on the WS upgrade across *all* groups, which is a harness artifact, not a real flake).
+
 Release/snapshot pipelines (`publish-snapshot.yml`, `publish-release.yml`) build multi-arch images (`amd64` + `arm64`) and stitch them with `docker manifest create`. Required GitHub secrets: `DOCKER_USERNAME`, `DOCKER_PASSWORD` (Docker Hub); `GITHUB_TOKEN` is provided automatically (GHCR). Release tag `v1.2.3` → image tag `1.2.3` (strip via `${VERSION#v}`).
 
 ## Troubleshooting

--- a/src/test/java/com/marcnuri/yakd/pod/PodExecEndpointTest.java
+++ b/src/test/java/com/marcnuri/yakd/pod/PodExecEndpointTest.java
@@ -17,9 +17,7 @@
  */
 package com.marcnuri.yakd.pod;
 
-import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.internal.WebSocketMessage;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -63,6 +61,11 @@ class PodExecEndpointTest {
 
   @BeforeEach
   void setUp() {
+    // Each shared mock settles the WebSocket upgrade by emitting an "OPEN" marker the endpoint
+    // forwards to the client (awaited as the upstream-connected gate) and is kept open by a
+    // never-matched expectation so it does not auto-close the instant its queues drain. Tests
+    // drive the close deterministically with a client-initiated session.close(...) rather than a
+    // shared wall-clock timer, which avoids the timed-close race fixed in #1830 (see #1834).
     for (var container : new String[]{"main", "sidecar"}) {
       kubernetes.expect()
         .get()
@@ -71,8 +74,8 @@ class PodExecEndpointTest {
         )
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(200L)
-        .andEmit(new WebSocketMessage(0L, "\u0003" + Serialization.asJson(new StatusBuilder().withStatus("Success").build()), false, true))
+        .waitFor(0L).andEmit("OPEN")
+        .expect("yakd-keep-open").andEmit("").always()
         .done()
         .always();
     }
@@ -88,6 +91,7 @@ class PodExecEndpointTest {
     void setUp() throws Exception {
       session = ContainerProvider.getWebSocketContainer().connectToServer(client, execUri);
       assertThat(client.openLatch.await(5, TimeUnit.SECONDS)).isTrue();
+      Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client.textMessages.contains("OPEN"));
     }
 
 
@@ -99,7 +103,8 @@ class PodExecEndpointTest {
 
     @Test
     @DisplayName("should receive close reason when connection closes")
-    void shouldReceiveCloseReason() {
+    void shouldReceiveCloseReason() throws Exception {
+      session.close(new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "Client closing"));
       Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client.closeReason.get() != null);
       assertThat(client.closeReason.get()).isNotNull();
     }
@@ -110,9 +115,11 @@ class PodExecEndpointTest {
       var client2 = new TestWebSocketClient();
       var session2 = ContainerProvider.getWebSocketContainer().connectToServer(client2, execUri);
       assertThat(client2.openLatch.await(5, TimeUnit.SECONDS)).isTrue();
+      Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client2.textMessages.contains("OPEN"));
 
       assertThat(session.getId()).isNotEqualTo(session2.getId());
 
+      session2.close(new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "Client closing"));
       Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client2.closeLatch.getCount() == 0);
     }
   }
@@ -231,9 +238,11 @@ class PodExecEndpointTest {
     @DisplayName("should handle connection to different container")
     void shouldHandleDifferentContainer() throws Exception {
       var uri = URI.create(execUri.toString().replace("/main", "/sidecar"));
-      ContainerProvider.getWebSocketContainer().connectToServer(client, uri);
+      var session = ContainerProvider.getWebSocketContainer().connectToServer(client, uri);
 
       assertThat(client.openLatch.await(5, TimeUnit.SECONDS)).isTrue();
+      Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client.textMessages.contains("OPEN"));
+      session.close(new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "Client closing"));
       Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client.closeReason.get() != null);
       assertThat(client.closeReason.get()).isNotNull();
     }
@@ -246,9 +255,11 @@ class PodExecEndpointTest {
     @Test
     @DisplayName("should trigger onClose handler when session closes")
     void shouldTriggerOnCloseHandler() throws Exception {
-      ContainerProvider.getWebSocketContainer().connectToServer(client, execUri);
+      var session = ContainerProvider.getWebSocketContainer().connectToServer(client, execUri);
       assertThat(client.openLatch.await(5, TimeUnit.SECONDS)).isTrue();
+      Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client.textMessages.contains("OPEN"));
 
+      session.close(new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "Client closing"));
       Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client.closeLatch.getCount() == 0);
       assertThat(client.closeReason)
         .doesNotHaveNullValue()
@@ -260,8 +271,10 @@ class PodExecEndpointTest {
     void shouldHandleRapidOpenCloseCycles() throws Exception {
       for (int i = 0; i < 3; i++) {
         client = new TestWebSocketClient();
-        ContainerProvider.getWebSocketContainer().connectToServer(client, execUri);
+        var session = ContainerProvider.getWebSocketContainer().connectToServer(client, execUri);
         assertThat(client.openLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client.textMessages.contains("OPEN"));
+        session.close(new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "Client closing"));
         Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> client.closeLatch.getCount() == 0);
       }
     }


### PR DESCRIPTION
## What

The remaining `PodExecEndpointTest` nested groups derived their close signal from the shared 200ms `waitFor` timer in `setUp` — a latent wall-clock dependence (robustness/clarity debt, not a live bug). This migrates them to the deterministic-by-construction pattern landed in #192 for the message-transmission group:

- **Shared `setUp` mock**: replace the 200ms timed close with an `OPEN` marker (`waitFor(0L).andEmit("OPEN")`) plus a never-matched keep-open expectation, so it settles the upgrade and never auto-closes.
- **Migrated tests** (`ConnectionLifecycleTests` ×2, `ConnectionCleanupTests` ×2, `ErrorHandlingTests.shouldHandleDifferentContainer`): gate on the `OPEN` marker (upstream connected), then close causally via client-initiated `session.close(NORMAL_CLOSURE)`.
- The two error-path tests stay as-is — their upstream connect fails (`UNEXPECTED_CONDITION`), so there is no timer and no gate to await.
- Remove now-unused imports.

Also documents the contention-flake repro method in `AGENTS.md` (use a CPU-limited Docker container, not host CPU-burner loops).

## Verification

- No group derives its close from the shared 200ms timer.
- 50/50 consecutive contended runs (`--cpus=2`) pass, with zero `StacklessClosedChannelException` and zero `Awaitility` timeout.

Closes https://github.com/manusa/com.marcnuri.automated-tasks/issues/1834