### PR TITLE
ci: evaluate arm64 runner for app-tests job

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,7 +25,7 @@ jobs:
 
   app-tests:
     name: App tests (Java unit + Selenium UI)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -41,17 +41,16 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Provision Chromium for Selenium
-        # arm64 Linux has no Google Chrome and no Chrome-for-Testing build, so Selenium Manager
-        # cannot resolve a driver. Install Chromium + a matching chromedriver instead.
-        uses: browser-actions/setup-chrome@v1
-        with:
-          install-chromedriver: true
-      - name: Export browser + driver paths
+        # arm64 Linux has no Google Chrome / Chrome-for-Testing build (so Selenium Manager cannot
+        # resolve a driver) and browser-actions/setup-chrome does not support arm64. The Chromium
+        # snap ships a matching chromium.chromedriver, so install that and resolve both paths.
         run: |
-          chrome_bin="$(command -v chrome || command -v chromium || command -v chromium-browser || true)"
-          driver_bin="$(command -v chromedriver || true)"
-          echo "Resolved CHROME_BIN=$chrome_bin"
-          echo "Resolved CHROME_DRIVER_BIN=$driver_bin"
+          set -x
+          sudo snap install chromium
+          chrome_bin="$(command -v chromium || echo /snap/bin/chromium)"
+          driver_bin="$(command -v chromium.chromedriver || echo /snap/bin/chromium.chromedriver)"
+          "$chrome_bin" --version
+          "$driver_bin" --version
           echo "CHROME_BIN=$chrome_bin" >> "$GITHUB_ENV"
           echo "CHROME_DRIVER_BIN=$driver_bin" >> "$GITHUB_ENV"
       - name: Test the app

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -40,6 +40,20 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+      - name: Provision Chromium for Selenium
+        # arm64 Linux has no Google Chrome and no Chrome-for-Testing build, so Selenium Manager
+        # cannot resolve a driver. Install Chromium + a matching chromedriver instead.
+        uses: browser-actions/setup-chrome@v1
+        with:
+          install-chromedriver: true
+      - name: Export browser + driver paths
+        run: |
+          chrome_bin="$(command -v chrome || command -v chromium || command -v chromium-browser || true)"
+          driver_bin="$(command -v chromedriver || true)"
+          echo "Resolved CHROME_BIN=$chrome_bin"
+          echo "Resolved CHROME_DRIVER_BIN=$driver_bin"
+          echo "CHROME_BIN=$chrome_bin" >> "$GITHUB_ENV"
+          echo "CHROME_DRIVER_BIN=$driver_bin" >> "$GITHUB_ENV"
       - name: Test the app
         run: make test-app
 

--- a/src/test/java/com/marcnuri/yakd/selenium/SeleniumTestResource.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/SeleniumTestResource.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -40,15 +41,27 @@ public class SeleniumTestResource implements QuarkusTestResourceConfigurableLife
 
   @Override
   public Map<String, String> start() {
-    chromeDriverService = new ChromeDriverService.Builder()
-      .usingAnyFreePort()
-      .build();
+    final ChromeDriverService.Builder serviceBuilder = new ChromeDriverService.Builder()
+      .usingAnyFreePort();
+    // Platforms without a Selenium Manager-resolvable driver (e.g. linux-arm64, where there is no
+    // Chrome-for-Testing build) can supply an explicit driver via webdriver.chrome.driver/CHROME_DRIVER_BIN.
+    final String driverPath = configured("webdriver.chrome.driver", "CHROME_DRIVER_BIN");
+    if (driverPath != null) {
+      serviceBuilder.usingDriverExecutable(new File(driverPath));
+    }
+    chromeDriverService = serviceBuilder.build();
     try {
       chromeDriverService.start();
     } catch (IOException exception) {
       throw new IllegalStateException("Unable to start ChromeDriverService", exception);
     }
     final ChromeOptions chromeOptions = new ChromeOptions();
+    // Likewise, a non-default browser binary (e.g. Chromium) can be supplied via
+    // webdriver.chrome.binary/CHROME_BIN; unset falls back to the auto-detected browser.
+    final String browserBinary = configured("webdriver.chrome.binary", "CHROME_BIN");
+    if (browserBinary != null) {
+      chromeOptions.setBinary(browserBinary);
+    }
     if (headless) {
       chromeOptions.addArguments("--headless=new");
     }
@@ -69,5 +82,15 @@ public class SeleniumTestResource implements QuarkusTestResourceConfigurableLife
   @Override
   public void inject(TestInjector testInjector) {
     testInjector.injectIntoFields(chromeDriver, new TestInjector.MatchesType(WebDriver.class));
+  }
+
+  // Resolves an optional path from a system property first, then an environment variable.
+  // Returns null when neither is set, preserving the default Selenium Manager-based behavior.
+  private static String configured(String systemProperty, String environmentVariable) {
+    String value = System.getProperty(systemProperty);
+    if (value == null || value.isBlank()) {
+      value = System.getenv(environmentVariable);
+    }
+    return value == null || value.isBlank() ? null : value;
   }
 }


### PR DESCRIPTION
## What

Evaluation PR (kept **draft**) for lever 1 of manusa/com.marcnuri.automated-tasks#1832: move the `app-tests` job from `ubuntu-latest` (amd64) to `ubuntu-24.04-arm`. Only `app-tests` is switched — the #1832 baseline showed `license-check` (~5s) and `frontend-tests` (~17s) run in parallel and are never on the critical path; `app-tests` (p50 **105s**) *is* the total wall-clock.

## Why

arm64 public runners bill at the same per-minute rate and are typically faster in aggregate on JVM work. The compressible mass inside `make test-app` is serial CPU work (two Quarkus first-class startups ≈ 26s + ~15s augmentation + Vite ≈ 5.5s).

## How this is evaluated

- **Probe-first:** Google ships no Chrome for Linux arm64 and Chrome-for-Testing has no `linux-arm64` build, so the Selenium ITs (`HomeIT`/`PodLogsIT`/`PodExecIT`) may fail until Chromium is provisioned. The first arm64 run on this branch determines whether that's needed; any provisioning is added in a follow-up commit here.
- **Measure:** 10 same-commit reruns of this branch, compared to the amd64 baseline (p50 105s / p95 124s).
- **Decision gate:** adopt only if **≥15% faster at the same cost** (Chrome-provisioning time, if any, counts against the gain). Otherwise this PR is closed with a documented deferral.

Not for merge until the 10-run sample clears the bar.

Refs: manusa/com.marcnuri.automated-tasks#1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)