### PR TITLE
ci: split app-tests into parallel unit and IT jobs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -23,8 +23,23 @@ jobs:
       - name: Check license headers
         run: make license-check
 
-  app-tests:
-    name: App tests (Java unit + Selenium UI)
+  unit-tests:
+    name: Unit tests (Java)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Run unit tests
+        run: make test-unit
+
+  it-tests:
+    name: Integration tests (Selenium UI)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,8 +55,8 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-      - name: Test the app
-        run: make test-app
+      - name: Run integration tests
+        run: make test-it
 
   frontend-tests:
     name: Frontend tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ Use the `Makefile`. CI runs these exact targets (`.github/workflows/build-and-te
 |---------------------------------------|--------------------------|
 | Fast "still wired together" check     | `make quick-build`       |
 | Full build (frontend + backend)       | `make build`             |
-| Test the Quarkus app (CI's `app-tests` job) | `make test-app`    |
+| Test the Quarkus app — all of it (local)    | `make test-app`    |
+| Java unit tests only (CI's `unit-tests` job) | `make test-unit`  |
+| Selenium UI tests only (CI's `it-tests` job) | `make test-it`    |
 | Full local CI mirror — am I ready to push? | `make check`         |
 | Backend dev loop (hot reload, :8080)  | `make dev-backend`       |
 | Frontend dev loop (Vite, :3000)       | `make dev-frontend`      |
@@ -156,15 +158,16 @@ The day-one knowledge. Each tied to a file path so you can verify it didn't drif
 
 ## CI reproduction
 
-`.github/workflows/build-and-test.yaml` runs three jobs in parallel (`license-check`, `app-tests`, `frontend-tests`). Reproduce locally:
+`.github/workflows/build-and-test.yaml` runs four jobs in parallel (`license-check`, `unit-tests`, `it-tests`, `frontend-tests`). The Surefire (unit) and Failsafe (Selenium IT) phases are split into separate jobs so their Quarkus boots overlap instead of stacking. Reproduce locally:
 
 ```bash
-make test-app        # Java unit + Selenium UI against the packaged app — CI's `app-tests` job
+make test-unit       # Java unit tests (Surefire, no frontend) — CI's `unit-tests` job
+make test-it         # Selenium UI tests (Failsafe + frontend) — CI's `it-tests` job
 make test-frontend   # Vitest — CI's `frontend-tests` job
 make license-check   # Apache header check — CI's `license-check` job
 ```
 
-Or one-shot via `make check` — it chains the same three targets through Make composition (`check: test license-check`, `test: test-app test-frontend`).
+`make test-app` runs the unit + Selenium phases together in one Quarkus build (the efficient local all-in-one; CI splits them across the `unit-tests` + `it-tests` jobs for wall-clock parallelism). Or one-shot via `make check` (`check: test license-check`, `test: test-app test-frontend`).
 
 ### Reproducing contention/timing flakes
 

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,12 @@ native: ## Build native image (frontend + GraalVM native)
 test-app: ## Test the Quarkus app (Java unit + Selenium UI against the packaged app)
 	mvn -Pbuild-frontend verify
 
+.PHONY: test-unit
+test-unit: ## Java unit tests only (Surefire — no frontend bundle, no Selenium/browser)
+	mvn test
+
 .PHONY: test-it
-test-it: ## Iteration helper: only the Selenium UI tests (set IT=Class[,Other] to filter)
+test-it: ## Selenium UI tests only (Failsafe + frontend bundle; set IT=Class[,Other] to filter)
 	mvn -Pbuild-frontend verify -Dsurefire.skip=true $(if $(IT),-Dit.test='$(IT)',)
 
 .PHONY: test-frontend


### PR DESCRIPTION
## What

Lever 7 of manusa/com.marcnuri.automated-tasks#1832. Split the single `app-tests` job into two parallel jobs:

- **`unit-tests`** — `make test-unit` (`mvn test`): Surefire only, no frontend bundle, no browser (so it needs neither Node nor Chrome setup).
- **`it-tests`** — `make test-it`: Failsafe (Selenium UI) + frontend bundle.

`make test-app` is kept as the local all-in-one; only CI splits the phases.

## Why

The #1832 baseline showed `app-tests` (~105s p50) is the **entire** CI critical path, and it runs Surefire then Failsafe **sequentially** in one job — each paying its own Quarkus cold-boot (~14.5s default profile + ~11.5s IT profile). Running them on separate runners overlaps those two boots instead of stacking them, so the critical path drops to roughly the slower of the two phases.

Expected: critical path ~105s → ~it-tests job (frontend ~20s + Failsafe ~30s + setup) ≈ **~60–65s (~35–40% faster)**, clearing the issue's ≥25% wall-clock target. Trade-off: ~2× the runner-minutes for the app-test work (the issue accepts this when per-shard runtime ≫ setup cost, which holds here). Measured wall-clock vs the amd64 baseline will be posted on the issue.

## Validated locally

- `make test-unit` → **65 unit tests pass** (BUILD SUCCESS), no frontend bundle built.
- `make test-it` → **10 IT tests across the 3 `*IT` classes pass** (BUILD SUCCESS).

No test-code changes; CLAUDE.md/AGENTS.md updated to document the four-job layout.

Refs: manusa/com.marcnuri.automated-tasks#1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)