### PR TITLE
test: add data-testid hooks to shared list components

### DIFF
--- a/src/main/frontend/src/components/ResourceListV2.jsx
+++ b/src/main/frontend/src/components/ResourceListV2.jsx
@@ -55,6 +55,7 @@ export const ResourceListV2 = ({
   }
   return (
     <Table
+      data-testid='resource-list'
       title={title}
       titleVariant={titleVariant}
       className={className}

--- a/src/main/frontend/src/components/Table.jsx
+++ b/src/main/frontend/src/components/Table.jsx
@@ -52,6 +52,7 @@ Table.Row = ({children, className = '', ...properties}) => (
 );
 Table.ResourceRow = ({resource, children, ...properties}) => (
   <Table.Row
+    data-testid='resource-list__row'
     className={deletionTimestamp(resource) ? 'line-through' : ''}
     {...properties}
   >

--- a/src/main/frontend/src/components/__test__/ResourceListV2.test.jsx
+++ b/src/main/frontend/src/components/__test__/ResourceListV2.test.jsx
@@ -286,4 +286,13 @@ describe('ResourceListV2 component tests', () => {
       expect(container.getAttribute('data-testid')).toBe('my-table');
     });
   });
+
+  describe('data-testid hooks', () => {
+    test('should emit a default data-testid of "resource-list" on the container when none is provided', () => {
+      const doc = renderList({resources: [{id: 1}]});
+
+      const container = doc.body.firstChild;
+      expect(container.getAttribute('data-testid')).toBe('resource-list');
+    });
+  });
 });

--- a/src/main/frontend/src/components/__test__/Table.test.jsx
+++ b/src/main/frontend/src/components/__test__/Table.test.jsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import React from 'react';
+import {describe, test, expect} from 'vitest';
+import {renderToString} from 'react-dom/server';
+import {parseHtml} from '../../test-utils';
+import {Table} from '../Table';
+
+const renderResourceRow = props => {
+  const html = renderToString(
+    <table>
+      <tbody>
+        <Table.ResourceRow resource={{}} {...props}>
+          <Table.Cell>Cell content</Table.Cell>
+        </Table.ResourceRow>
+      </tbody>
+    </table>
+  );
+  return parseHtml(html);
+};
+
+describe('Table component tests', () => {
+  describe('ResourceRow data-testid hooks', () => {
+    test('should emit a default data-testid of "resource-list__row" on the row when none is provided', () => {
+      const doc = renderResourceRow();
+
+      const row = doc.querySelector('tr');
+      expect(row.getAttribute('data-testid')).toBe('resource-list__row');
+    });
+
+    test('should allow overriding the default row data-testid', () => {
+      const doc = renderResourceRow({'data-testid': 'list__events-row'});
+
+      const row = doc.querySelector('tr');
+      expect(row.getAttribute('data-testid')).toBe('list__events-row');
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds stable, overridable `data-testid` hooks to the shared list components so
full-stack Selenium ITs can locate lists and rows without brittle text/CSS selectors.

- `ResourceListV2` container → default `data-testid="resource-list"`
- `Table.ResourceRow` → default `data-testid="resource-list__row"`

Both defaults are placed before the props spread, so existing per-feature testids
(e.g. `events`' `list__events` / `list__events-row`) continue to override them. This
lights up all 27 list pages at once with zero per-feature changes.

## Why

`ResourceListV2` (the shared table behind every list page) previously emitted no
`data-testid`, called out in the coverage audit as the first blocker (slice **T1**)
for expanding full-stack IT coverage.

## Tests

- TDD: new default-emit tests for the container (`ResourceListV2.test.jsx`) and the
  row (`Table.test.jsx`), plus a row-override regression test.
- `make test-frontend` → 148/148 pass.
- `make test-it IT=HomeIT` → 3/3 pass (confirms the bundle builds and `events`'
  overrides survive end-to-end).
- `make lint` / `make typecheck` / `make fmt-check` clean.

## Scope / follow-ups

Generic hooks intentionally cover single-list pages. Per-feature prefixes and a
`…__name-link` hook (needed only for the multi-list Search page, slice X2) are
deferred and addable later via the override prop. Action-menu/`Modal` hooks (T2)
and convention docs (T4) are separate slices.

Slice T1 of manusa/com.marcnuri.automated-tasks#1844