### PR TITLE
test: add filter/sidebar testid hooks and deployment mutation ITs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,22 @@ public class PodLogsIT {
 }
 ```
 
-UI elements that tests need to find are marked with `data-testid`. Most newer IDs follow `<feature>__<element>` (e.g. `pod-list__logs-link`, `pod-logs__content`); older ones use single tokens (e.g. `container-dropdown`). Prefer `data-testid` over class names or text content when adding new selectors.
+UI elements that tests need to find are marked with `data-testid`. Prefer `data-testid` over class names or text content for anything a test selects.
+
+**Naming convention: `<feature>__<element>`** — double-underscore separator, both parts kebab-case (e.g. `pod-list__logs-link`, `resource-edit__save`, `filter-bar__namespace-item`). A few legacy hooks use a single token (`container-dropdown`); use the two-part form for new ones. For an element that repeats (list rows, menu items), reuse one id across the set and match the specific instance by its visible text.
+
+**Shared components emit overridable defaults.** Components reused across every feature (`ResourceListV2`, `Table.ResourceRow`/`Table.DeleteButton`, `Modal`, `PopupMenu`, the editor Save/Cancel) render a generic default `data-testid` placed **before** the `{...props}` spread, so a caller can override it with a feature-specific id. That is why `events/List.jsx` keeps `list__events`/`list__events-row` while every other list inherits `resource-list`/`resource-list__row`. Stable shared hooks:
+
+| Hook | Element |
+|---|---|
+| `resource-list` / `resource-list__row` | shared list container / row |
+| `resource-list__delete` | list-row delete button |
+| `resource-detail__delete` / `resource-detail__download` | detail-page action items |
+| `resource-edit__save` / `resource-edit__cancel` | YAML editor Save / Cancel |
+| `popup-menu__trigger` | action-menu trigger |
+| `modal` | modal dialog container |
+| `filter-bar__namespace` / `filter-bar__all-namespaces` / `filter-bar__namespace-item` | namespace filter |
+| `side-bar__nav-<route>` | sidebar nav link (e.g. `side-bar__nav-deployments`) |
 
 ### Frontend tests (Vitest)
 

--- a/src/main/frontend/src/components/FilterBar.jsx
+++ b/src/main/frontend/src/components/FilterBar.jsx
@@ -29,18 +29,23 @@ const NamespaceDropdown = () => {
   } = useUiNamespace();
   return (
     <Dropdown
+      data-testid='filter-bar__namespace'
       closeOnPanelClick={true}
       text={selectedNamespace ?? 'Namespace'}
       textColor={selectedNamespace ? 'text-blue-700' : 'text-gray-500'}
       textColorActive={selectedNamespace ? 'text-blue-800' : null}
     >
-      <Dropdown.Item onClick={clearSelectedNamespace}>
+      <Dropdown.Item
+        data-testid='filter-bar__all-namespaces'
+        onClick={clearSelectedNamespace}
+      >
         All namespaces
       </Dropdown.Item>
       {Object.values(namespaces)
         .map(ns => name(ns))
         .map(namespace => (
           <Dropdown.Item
+            data-testid='filter-bar__namespace-item'
             key={namespace}
             onClick={() => selectNamespace(namespace)}
           >

--- a/src/main/frontend/src/components/__test__/FilterBar.test.jsx
+++ b/src/main/frontend/src/components/__test__/FilterBar.test.jsx
@@ -349,4 +349,41 @@ describe('FilterBar component tests', () => {
       expect(menu.textContent).toContain(longName);
     });
   });
+
+  describe('data-testid hooks', () => {
+    test('should mark the namespace dropdown with a data-testid', () => {
+      const doc = renderFilterBar();
+
+      const dropdown = doc.querySelector(
+        '[data-testid="filter-bar__namespace"]'
+      );
+      expect(dropdown).not.toBeNull();
+    });
+
+    test('should mark the "All namespaces" option with a data-testid', () => {
+      const doc = renderFilterBar();
+
+      const allNamespaces = doc.querySelector(
+        '[data-testid="filter-bar__all-namespaces"]'
+      );
+      expect(allNamespaces.textContent).toContain('All namespaces');
+    });
+
+    test('should mark each namespace option with a data-testid', () => {
+      const namespaces = {
+        'uid-1': {kind: 'Namespace', metadata: {uid: 'uid-1', name: 'default'}},
+        'uid-2': {
+          kind: 'Namespace',
+          metadata: {uid: 'uid-2', name: 'kube-system'}
+        }
+      };
+
+      const doc = renderFilterBar({namespaces});
+
+      const items = doc.querySelectorAll(
+        '[data-testid="filter-bar__namespace-item"]'
+      );
+      expect(items).toHaveLength(2);
+    });
+  });
 });

--- a/src/main/frontend/src/dashboard/SideBar.jsx
+++ b/src/main/frontend/src/dashboard/SideBar.jsx
@@ -54,6 +54,8 @@ import {
 
 import './SideBar.css';
 
+const navTestId = to => `side-bar__nav-${to.replace(/^\//, '') || 'home'}`;
+
 const RoutedLink = ({
   to,
   staticContext: _staticContext,
@@ -106,14 +108,14 @@ const NavGroup = ({expandedItems, toggleItem, label, icon, children}) => {
 };
 
 const K8sNavItem = ({to, Icon: ComponentIcon, children}) => (
-  <RoutedLink to={to}>
+  <RoutedLink to={to} data-testid={navTestId(to)}>
     <ComponentIcon className='side-bar__nav-item-icon' />
     {children}
   </RoutedLink>
 );
 
 const IconNavItem = ({to, icon, children}) => (
-  <RoutedLink to={to}>
+  <RoutedLink to={to} data-testid={navTestId(to)}>
     <Icon className='side-bar__nav-item-icon' icon={icon} />
     {children}
   </RoutedLink>

--- a/src/main/frontend/src/dashboard/__test__/SideBar.test.jsx
+++ b/src/main/frontend/src/dashboard/__test__/SideBar.test.jsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import React from 'react';
+import {describe, test, expect} from 'vitest';
+import {renderToString} from 'react-dom/server';
+import {StaticRouter} from 'react-router-dom/server';
+import {Provider} from 'react-redux';
+import {createTestStore, parseHtml} from '../../test-utils';
+import {SideBar} from '../SideBar';
+
+const renderSideBar = (storeState = {}) => {
+  const store = createTestStore(storeState);
+  const html = renderToString(
+    <Provider store={store}>
+      <StaticRouter location='/'>
+        <SideBar sideBarOpen={true} />
+      </StaticRouter>
+    </Provider>
+  );
+  return parseHtml(html);
+};
+
+describe('SideBar component tests', () => {
+  describe('data-testid hooks', () => {
+    test('should mark the Search nav link with a data-testid', () => {
+      const doc = renderSideBar();
+
+      expect(
+        doc.querySelector('[data-testid="side-bar__nav-search"]')
+      ).not.toBeNull();
+    });
+
+    test('should mark the Home nav link with a data-testid', () => {
+      const doc = renderSideBar();
+
+      expect(
+        doc.querySelector('[data-testid="side-bar__nav-home"]')
+      ).not.toBeNull();
+    });
+
+    test('should mark the Pods nav link with a data-testid', () => {
+      const doc = renderSideBar();
+
+      expect(
+        doc.querySelector('[data-testid="side-bar__nav-pods"]')
+      ).not.toBeNull();
+    });
+
+    test('should mark the Deployments nav link with a data-testid', () => {
+      const doc = renderSideBar();
+
+      expect(
+        doc.querySelector('[data-testid="side-bar__nav-deployments"]')
+      ).not.toBeNull();
+    });
+  });
+
+  describe('OpenShift-mode nav', () => {
+    test('hides the Deployment Configs nav link on vanilla Kubernetes', () => {
+      const doc = renderSideBar();
+
+      expect(
+        doc.querySelector('[data-testid="side-bar__nav-deploymentconfigs"]')
+      ).toBeNull();
+    });
+
+    test('shows the Deployment Configs nav link in OpenShift mode', () => {
+      const doc = renderSideBar({apiGroups: ['apps.openshift.io']});
+
+      expect(
+        doc.querySelector('[data-testid="side-bar__nav-deploymentconfigs"]')
+      ).not.toBeNull();
+    });
+  });
+});

--- a/src/main/frontend/src/test-utils/store.js
+++ b/src/main/frontend/src/test-utils/store.js
@@ -17,7 +17,11 @@
 // TODO: Replace createStore with configureStore from @reduxjs/toolkit when redux is updated
 // createStore is deprecated: https://redux.js.org/introduction/why-rtk-is-redux-today
 import {combineReducers, createStore} from 'redux';
+// Import the redux barrel before the apis barrel: redux re-exports the
+// production store, whose module-load combineReducers reads apis.apiGroupsReducer.
+// Loading apis first would re-enter it mid-initialization (apis <-> redux cycle).
 import {reducer as reduxReducer, uiReducer} from '../redux';
+import {apiGroupsReducer} from '../apis';
 
 /**
  * Creates a Redux store for testing with optional initial state.
@@ -27,6 +31,8 @@ import {reducer as reduxReducer, uiReducer} from '../redux';
  */
 export const createTestStore = (initialState = {}) => {
   const appReducer = combineReducers({
+    apiGroups: apiGroupsReducer,
+    customResourceDefinitions: reduxReducer('CustomResourceDefinition'),
     namespaces: reduxReducer('Namespace'),
     ui: uiReducer
   });

--- a/src/test/java/com/marcnuri/yakd/deployment/DeploymentMutationIT.java
+++ b/src/test/java/com/marcnuri/yakd/deployment/DeploymentMutationIT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.deployment;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Deployment mutation paths")
+public class DeploymentMutationIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String DEPLOYMENT_NAME = "mutation-it-deployment";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().apps().deployments().inNamespace(NAMESPACE)
+      .resource(deployment()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().apps().deployments().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Deployment deployment() {
+    return new DeploymentBuilder()
+      .withNewMetadata()
+        .withName(DEPLOYMENT_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewSpec()
+        .withReplicas(1)
+        .withNewSelector().addToMatchLabels("app", DEPLOYMENT_NAME).endSelector()
+        .withNewTemplate()
+          .withNewMetadata().addToLabels("app", DEPLOYMENT_NAME).endMetadata()
+          .withNewSpec()
+            .addNewContainer().withName("container-1").withImage("busybox").endContainer()
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .build();
+  }
+
+  private boolean listHasDeploymentRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(DEPLOYMENT_NAME));
+  }
+
+  private String backendMarker() {
+    final Deployment deployment = kubernetes.getClient().apps().deployments()
+      .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
+    if (deployment == null || deployment.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return deployment.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "deployments");
+      wait.until(d -> listHasDeploymentRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the deployment's row from the list")
+    void deleteRemovesRow() {
+      driver.findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasDeploymentRow());
+      assertThat(listHasDeploymentRow())
+        .as("deployment row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      // The MockServer assigns its own uid on create, so resolve the stored uid
+      // rather than relying on a client-provided one; the edit page keys off it.
+      final Deployment seeded = kubernetes.getClient().apps().deployments()
+        .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
+      assertThat(seeded).as("seeded deployment available before editing").isNotNull();
+      driver.navigate().to(url.toString() + "deployments/" + seeded.getMetadata().getUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted deployment")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}


### PR DESCRIPTION
## What

Expands the Selenium IT coverage audited in the tracking issue, landing four slices in one PR.

### T3 — testability hooks
- `FilterBar`: `filter-bar__namespace` (dropdown), `filter-bar__all-namespaces`, `filter-bar__namespace-item`.
- `SideBar`: `side-bar__nav-<route>` on every static nav item (e.g. `side-bar__nav-deployments`, `side-bar__nav-deploymentconfigs`).
- `createTestStore` gains the `apiGroups` and `customResourceDefinitions` reducers so `SideBar` is unit-renderable (it reads `apiGroups`). Imports are ordered redux-barrel-before-apis-barrel to avoid a circular-import warning from the production store.

### T4 — documentation
- Documents the `<feature>__<element>` `data-testid` convention, the shared-component overridable-default pattern, and a table of stable hooks in `AGENTS.md`.

### M1 + M2 — first mutation-path ITs
New `DeploymentMutationIT` (`@Nested`, one Quarkus boot) against the Fabric8 MockServer:
- **M1 delete** — clicking the list delete button removes the row, confirming the watch propagates a live `DELETED` event end-to-end (list removal is purely watch-driven).
- **M2 edit-save** — editing the YAML in the editor and saving persists the change to the backend, asserted via the Kubernetes client (the `PUT` round-trips through the MockServer).

## Testing
- `make test-frontend` — 164 Vitest pass
- `make test-unit` — 65 unit tests pass (the new `*IT` is correctly excluded from Surefire)
- `make test-it` — 12 ITs pass (including the 2 new ones), no regression
- `make license-check`, lint, typecheck, and prettier checks all pass

Tracking: manusa/com.marcnuri.automated-tasks#1844 (slices T3, T4, M1, M2)