### PR TITLE
test: add scale, restart, and cronjob suspend mutation ITs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ UI elements that tests need to find are marked with `data-testid`. Prefer `data-
 | `resource-list` / `resource-list__row` | shared list container / row |
 | `resource-list__delete` | list-row delete button |
 | `resource-detail__delete` / `resource-detail__download` | detail-page action items |
+| `replicas-field__increment` / `replicas-field__decrement` | scale carets on the shared `ReplicasField` (deployments / statefulsets / deploymentconfigs) |
 | `resource-edit__save` / `resource-edit__cancel` | YAML editor Save / Cancel |
 | `popup-menu__trigger` | action-menu trigger |
 | `modal` | modal dialog container |

--- a/src/main/frontend/src/cronjobs/CronJobsDetailPage.jsx
+++ b/src/main/frontend/src/cronjobs/CronJobsDetailPage.jsx
@@ -31,6 +31,7 @@ const SuspendField = ({cronJob}) => {
       <div className='flex items-center'>
         <div className='flex flex-col mr-1 text-blue-600'>
           <Icon
+            data-testid='cronjob-detail__suspend-toggle'
             icon={isSuspended ? 'fa-play-circle' : 'fa-pause-circle'}
             className='pr-1 py-1 leading-3 hover:text-blue-800 cursor-pointer'
             onClick={toggleSuspend}

--- a/src/main/frontend/src/deployments/List.jsx
+++ b/src/main/frontend/src/deployments/List.jsx
@@ -66,6 +66,7 @@ const Rows = ({deployments}) => {
       </Table.Cell>
       <Table.Cell className='whitespace-nowrap text-center'>
         <Link
+          data-testid='deployment-list__restart'
           variant={Link.variants.outline}
           onClick={restartDeployment(deployment)}
           title='Restart'

--- a/src/main/frontend/src/replicasets/ReplicasField.jsx
+++ b/src/main/frontend/src/replicasets/ReplicasField.jsx
@@ -24,11 +24,13 @@ export const ReplicasField = ({replicas, resource, updateReplicas}) => (
       {replicas}
       <div className='flex flex-col ml-2 text-blue-600'>
         <Icon
+          data-testid='replicas-field__increment'
           icon='fa-caret-up'
           className='leading-3 hover:text-blue-800 cursor-pointer'
           onClick={() => updateReplicas(resource, replicas + 1)}
         />
         <Icon
+          data-testid='replicas-field__decrement'
           icon='fa-caret-down'
           className={`leading-3 ${
             replicas > 0

--- a/src/test/java/com/marcnuri/yakd/cronjobs/CronJobMutationIT.java
+++ b/src/test/java/com/marcnuri/yakd/cronjobs/CronJobMutationIT.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.cronjobs;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.batch.v1.CronJob;
+import io.fabric8.kubernetes.api.model.batch.v1.CronJobBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("CronJob mutation paths")
+public class CronJobMutationIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String CRONJOB_NAME = "mutation-it-cronjob";
+  private static final By TOGGLE = By.cssSelector("[data-testid='cronjob-detail__suspend-toggle']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().batch().v1().cronjobs().inNamespace(NAMESPACE)
+      .resource(cronJob(false)).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().batch().v1().cronjobs().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static CronJob cronJob(boolean suspend) {
+    return new CronJobBuilder()
+      .withNewMetadata()
+        .withName(CRONJOB_NAME)
+        .withNamespace(NAMESPACE)
+      .endMetadata()
+      .withNewSpec()
+        .withSchedule("*/1 * * * *")
+        .withSuspend(suspend)
+        .withNewJobTemplate()
+          .withNewSpec()
+            .withNewTemplate()
+              .withNewSpec()
+                .addNewContainer().withName("container-1").withImage("busybox").endContainer()
+                .withRestartPolicy("OnFailure")
+              .endSpec()
+            .endTemplate()
+          .endSpec()
+        .endJobTemplate()
+      .endSpec()
+      .build();
+  }
+
+  // Navigate to the detail page of the seeded CronJob and wait until the watch has
+  // loaded it into the store. The toggle renders fa-pause-circle for an undefined
+  // resource too (specSuspend(undefined) === false), so the name only renders once
+  // the resource is loaded and is the safe gate before trusting the toggle state.
+  private void navigateToDetail() {
+    final CronJob seeded = kubernetes.getClient().batch().v1().cronjobs()
+      .inNamespace(NAMESPACE).withName(CRONJOB_NAME).get();
+    assertThat(seeded).as("seeded cronjob available before navigating").isNotNull();
+    driver.navigate().to(url.toString() + "cronjobs/" + seeded.getMetadata().getUid());
+    wait.until(d -> d.getPageSource().contains(CRONJOB_NAME));
+  }
+
+  // The toggle renders fa-pause-circle while running and fa-play-circle while suspended,
+  // so its icon class is a reliable gate for the loaded state before clicking.
+  private boolean toggleShows(String iconClass) {
+    return driver.findElements(TOGGLE).stream()
+      .anyMatch(e -> e.getAttribute("class").contains(iconClass));
+  }
+
+  private Boolean backendSuspended() {
+    final CronJob cronJob = kubernetes.getClient().batch().v1().cronjobs()
+      .inNamespace(NAMESPACE).withName(CRONJOB_NAME).get();
+    if (cronJob == null || cronJob.getSpec() == null) {
+      return null;
+    }
+    return cronJob.getSpec().getSuspend();
+  }
+
+  @Nested
+  @DisplayName("when suspending a running cronjob")
+  class Suspend {
+
+    @BeforeEach
+    void navigate() {
+      navigateToDetail();
+      wait.until(d -> toggleShows("fa-pause-circle"));
+    }
+
+    @Test
+    @DisplayName("clicking the toggle suspends the cronjob in the backend")
+    void toggleSuspends() {
+      driver.findElement(TOGGLE).click();
+
+      wait.until(d -> Boolean.TRUE.equals(backendSuspended()));
+      assertThat(backendSuspended())
+        .as("spec.suspend on the persisted cronjob")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when resuming a suspended cronjob")
+  class Resume {
+
+    @BeforeEach
+    void navigate() {
+      kubernetes.getClient().batch().v1().cronjobs().inNamespace(NAMESPACE).withName(CRONJOB_NAME)
+        .edit(cronJob -> new CronJobBuilder(cronJob).editSpec().withSuspend(true).endSpec().build());
+      navigateToDetail();
+      wait.until(d -> toggleShows("fa-play-circle"));
+    }
+
+    @Test
+    @DisplayName("clicking the toggle resumes the cronjob in the backend")
+    void toggleResumes() {
+      driver.findElement(TOGGLE).click();
+
+      wait.until(d -> Boolean.FALSE.equals(backendSuspended()));
+      assertThat(backendSuspended())
+        .as("spec.suspend on the persisted cronjob")
+        .isFalse();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/deployment/DeploymentMutationIT.java
+++ b/src/test/java/com/marcnuri/yakd/deployment/DeploymentMutationIT.java
@@ -114,6 +114,28 @@ public class DeploymentMutationIT {
     return deployment.getMetadata().getLabels().get("mutation-marker");
   }
 
+  private Integer backendReplicas() {
+    final Deployment deployment = kubernetes.getClient().apps().deployments()
+      .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
+    if (deployment == null || deployment.getSpec() == null) {
+      return null;
+    }
+    return deployment.getSpec().getReplicas();
+  }
+
+  private String backendRestartedAt() {
+    final Deployment deployment = kubernetes.getClient().apps().deployments()
+      .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
+    if (deployment == null || deployment.getSpec() == null
+      || deployment.getSpec().getTemplate() == null
+      || deployment.getSpec().getTemplate().getMetadata() == null
+      || deployment.getSpec().getTemplate().getMetadata().getAnnotations() == null) {
+      return null;
+    }
+    return deployment.getSpec().getTemplate().getMetadata().getAnnotations()
+      .get("kubectl.kubernetes.io/restartedAt");
+  }
+
   @Nested
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
@@ -171,6 +193,55 @@ public class DeploymentMutationIT {
         "const e = document.querySelector('.ace_editor');"
           + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
       return value == null ? "" : value.toString();
+    }
+  }
+
+  @Nested
+  @DisplayName("when scaling from the detail page")
+  class Scale {
+
+    @BeforeEach
+    void navigate() {
+      final Deployment seeded = kubernetes.getClient().apps().deployments()
+        .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
+      assertThat(seeded).as("seeded deployment available before scaling").isNotNull();
+      driver.navigate().to(url.toString() + "deployments/" + seeded.getMetadata().getUid());
+      // The replicas control operates on the resource once the watch has loaded it
+      // into the store; the name only renders after that, so it is a safe gate.
+      wait.until(d -> d.getPageSource().contains(DEPLOYMENT_NAME));
+    }
+
+    @Test
+    @DisplayName("incrementing the replicas persists the new replica count to the backend")
+    void incrementPersistsReplicas() {
+      driver.findElement(By.cssSelector("[data-testid='replicas-field__increment']")).click();
+
+      wait.until(d -> Integer.valueOf(2).equals(backendReplicas()));
+      assertThat(backendReplicas())
+        .as("spec.replicas on the persisted deployment")
+        .isEqualTo(2);
+    }
+  }
+
+  @Nested
+  @DisplayName("when restarting from the list page")
+  class Restart {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "deployments");
+      wait.until(d -> listHasDeploymentRow());
+    }
+
+    @Test
+    @DisplayName("clicking restart records a rollout restart on the backend")
+    void restartRecordsRestartedAt() {
+      driver.findElement(By.cssSelector("[data-testid='deployment-list__restart']")).click();
+
+      wait.until(d -> backendRestartedAt() != null);
+      assertThat(backendRestartedAt())
+        .as("kubectl.kubernetes.io/restartedAt annotation on the persisted deployment")
+        .isNotNull();
     }
   }
 }


### PR DESCRIPTION
## What

Adds the remaining **mutation-path** Selenium ITs (priority group **M**)
from the coverage tracker, black-box against the Fabric8 MockServer:

- **M3 — Scale**: `DeploymentMutationIT.Scale` clicks the replicas
  increment caret on the deployment detail page and asserts
  `spec.replicas` is persisted to the backend.
- **M4 — Restart**: `DeploymentMutationIT.Restart` clicks restart on the
  list page and asserts the `kubectl.kubernetes.io/restartedAt` rollout
  annotation is recorded.
- **M5 — Suspend/Resume**: new `CronJobMutationIT` toggles suspend on the
  cronjob detail page and asserts `spec.suspend` flips both ways.

## Testability hooks

- `replicas-field__increment` / `replicas-field__decrement` on the shared
  `ReplicasField` (documented in the AGENTS.md shared-hook table).
- `deployment-list__restart` on the deployment list-row restart control.
- `cronjob-detail__suspend-toggle` on the cronjob suspend toggle.

## Notes

- M3/M4 are `@Nested` cases inside the existing `DeploymentMutationIT` to
  amortize the Quarkus cold-boot; only M5 adds one new IT class.
- Detail-page tests gate on the resource being loaded (name rendered)
  before clicking, then assert backend state via the Kubernetes client —
  robust against watch-refresh timing.

## Verification

- `make test-it IT=DeploymentMutationIT,CronJobMutationIT` → 6/6 pass
  (×3 consecutive runs).
- `make test-frontend` (164 pass), `make fmt-check`, `make typecheck`,
  `make lint` → all green.

Refs manusa/com.marcnuri.automated-tasks#1844 (slices M3, M4, M5)