### PR TITLE
test: add list/detail, namespace-filter, search, and OpenShift-mode ITs

### DIFF
--- a/src/main/frontend/src/components/Textfield.jsx
+++ b/src/main/frontend/src/components/Textfield.jsx
@@ -24,7 +24,8 @@ export const Textfield = ({
   placeholder,
   icon,
   inputRef,
-  borderColor = 'border-gray-300'
+  borderColor = 'border-gray-300',
+  ...props
 }) => (
   <div
     className={`
@@ -40,6 +41,7 @@ export const Textfield = ({
       type='text'
       className='flex-1 outline-none'
       placeholder={placeholder}
+      {...props}
       value={value}
       onChange={onChange}
     />

--- a/src/main/frontend/src/components/__test__/Textfield.test.jsx
+++ b/src/main/frontend/src/components/__test__/Textfield.test.jsx
@@ -35,15 +35,5 @@ describe('Textfield component tests', () => {
       const input = doc.querySelector('input');
       expect(input.getAttribute('data-testid')).toBe('search__input');
     });
-
-    test('should keep the controlled value when additional props are spread', () => {
-      const doc = renderTextfield({
-        'data-testid': 'search__input',
-        value: 'controlled-value'
-      });
-
-      const input = doc.querySelector('input');
-      expect(input.getAttribute('value')).toBe('controlled-value');
-    });
   });
 });

--- a/src/main/frontend/src/components/__test__/Textfield.test.jsx
+++ b/src/main/frontend/src/components/__test__/Textfield.test.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import React from 'react';
+import {describe, test, expect} from 'vitest';
+import {renderToString} from 'react-dom/server';
+import {parseHtml} from '../../test-utils';
+import {Textfield} from '../Textfield';
+
+const renderTextfield = props => {
+  const html = renderToString(
+    <Textfield value='' onChange={() => {}} {...props} />
+  );
+  return parseHtml(html);
+};
+
+describe('Textfield component tests', () => {
+  describe('additional props spreading', () => {
+    test('should spread a provided data-testid onto the input element', () => {
+      const doc = renderTextfield({'data-testid': 'search__input'});
+
+      const input = doc.querySelector('input');
+      expect(input.getAttribute('data-testid')).toBe('search__input');
+    });
+
+    test('should keep the controlled value when additional props are spread', () => {
+      const doc = renderTextfield({
+        'data-testid': 'search__input',
+        value: 'controlled-value'
+      });
+
+      const input = doc.querySelector('input');
+      expect(input.getAttribute('value')).toBe('controlled-value');
+    });
+  });
+});

--- a/src/main/frontend/src/search/SearchPage.jsx
+++ b/src/main/frontend/src/search/SearchPage.jsx
@@ -233,6 +233,7 @@ export const SearchPage = connect(
     <DashboardPage title='Query cluster resources'>
       <div className='flex mb-4'>
         <Textfield
+          data-testid='search__input'
           className='flex-1  mr-2'
           inputRef={inputRef}
           placeholder='Search'

--- a/src/test/java/com/marcnuri/yakd/ClusterScopedResourceIT.java
+++ b/src/test/java/com/marcnuri/yakd/ClusterScopedResourceIT.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Cluster-scoped resources")
+public class ClusterScopedResourceIT {
+
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private boolean listHasRow(String text) {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(text));
+  }
+
+  @Nested
+  @DisplayName("when viewing the Node list and detail pages")
+  class NodeListAndDetail {
+
+    private static final String NODE_NAME = "cluster-it-node";
+    private static final String KUBELET_VERSION = "v1.33.0-cluster-it";
+
+    @BeforeEach
+    void seed() {
+      kubernetes.getClient().nodes().resource(node()).createOr(NonDeletingOperation::update);
+    }
+
+    @AfterEach
+    void deleteNode() {
+      kubernetes.getClient().nodes().withName(NODE_NAME).delete();
+    }
+
+    private static Node node() {
+      return new NodeBuilder()
+        .withNewMetadata()
+          .withName(NODE_NAME)
+          .addToLabels("node-role.kubernetes.io/control-plane", "")
+        .endMetadata()
+        .withNewStatus()
+          .addToAllocatable("cpu", new Quantity("4"))
+          .addToAllocatable("memory", new Quantity("16Gi"))
+          .addToAllocatable("pods", new Quantity("110"))
+          .addNewCondition().withType("Ready").withStatus("True").endCondition()
+          .withNewNodeInfo()
+            .withOperatingSystem("linux")
+            .withArchitecture("arm64")
+            .withKernelVersion("6.6.0")
+            .withContainerRuntimeVersion("containerd://1.7.0")
+            .withKubeletVersion(KUBELET_VERSION)
+          .endNodeInfo()
+        .endStatus()
+        .build();
+    }
+
+    @Test
+    @DisplayName("the list renders a row for the seeded node")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "nodes");
+
+      wait.until(d -> listHasRow(NODE_NAME));
+      assertThat(listHasRow(NODE_NAME))
+        .as("row for the seeded node present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the name-keyed detail page renders the node's kubelet version")
+    void detailRendersKubeletVersion() {
+      driver.navigate().to(url.toString() + "nodes/" + NODE_NAME);
+
+      // The kubelet version can only come from the seeded node's status, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(KUBELET_VERSION));
+      assertThat(driver.getPageSource())
+        .as("node detail page contents")
+        .contains(KUBELET_VERSION);
+    }
+  }
+
+  @Nested
+  @DisplayName("when viewing the CustomResourceDefinition list and detail pages")
+  class CustomResourceDefinitionListAndDetail {
+
+    private static final String GROUP = "yakd.example.com";
+    private static final String VERSION = "v1";
+    private static final String PLURAL = "widgets";
+    private static final String CRD_NAME = PLURAL + "." + GROUP;
+    private static final String CUSTOM_RESOURCE_NAME = "cluster-it-widget";
+
+    @BeforeEach
+    void seed() {
+      kubernetes.getClient().apiextensions().v1().customResourceDefinitions()
+        .resource(customResourceDefinition()).createOr(NonDeletingOperation::update);
+      kubernetes.getClient().genericKubernetesResources(widgetContext())
+        .resource(new GenericKubernetesResourceBuilder()
+          .withApiVersion(GROUP + "/" + VERSION)
+          .withKind("Widget")
+          .withNewMetadata().withName(CUSTOM_RESOURCE_NAME).endMetadata()
+          .build())
+        .createOr(NonDeletingOperation::update);
+    }
+
+    @AfterEach
+    void deleteCustomResources() {
+      kubernetes.getClient().genericKubernetesResources(widgetContext())
+        .withName(CUSTOM_RESOURCE_NAME).delete();
+      kubernetes.getClient().apiextensions().v1().customResourceDefinitions()
+        .withName(CRD_NAME).delete();
+    }
+
+    private static ResourceDefinitionContext widgetContext() {
+      return new ResourceDefinitionContext.Builder()
+        .withNamespaced(false).withGroup(GROUP).withVersion(VERSION).withPlural(PLURAL).build();
+    }
+
+    private static CustomResourceDefinition customResourceDefinition() {
+      return new CustomResourceDefinitionBuilder()
+        .withNewMetadata()
+          .withName(CRD_NAME)
+        .endMetadata()
+        .withNewSpec()
+          .withGroup(GROUP)
+          .withScope("Cluster")
+          .withNewNames().withKind("Widget").withSingular("widget").withPlural(PLURAL).endNames()
+          .addNewVersion().withName(VERSION).withServed(true).withStorage(true).endVersion()
+        .endSpec()
+        .build();
+    }
+
+    private String customResourceDefinitionUid() {
+      final CustomResourceDefinition crd = kubernetes.getClient().apiextensions().v1()
+        .customResourceDefinitions().withName(CRD_NAME).get();
+      assertThat(crd).as("seeded custom resource definition available").isNotNull();
+      return crd.getMetadata().getUid();
+    }
+
+    @Test
+    @DisplayName("the list renders a row for the seeded custom resource definition")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "customresourcedefinitions");
+
+      wait.until(d -> listHasRow(CRD_NAME));
+      assertThat(listHasRow(CRD_NAME))
+        .as("row for the seeded custom resource definition present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the custom resource definition's kind")
+    void detailRendersKind() {
+      driver.navigate().to(url.toString() + "customresourcedefinitions/" + customResourceDefinitionUid());
+
+      // Case-sensitive match: 'Widget' can only come from the CRD's spec.names.kind
+      // (the CRD name only contains the lowercase plural form).
+      wait.until(d -> d.getPageSource().contains("Widget"));
+      assertThat(driver.getPageSource())
+        .as("custom resource definition detail page contents")
+        .contains("Widget");
+    }
+
+    @Test
+    @DisplayName("the detail page lists the seeded custom resource instance")
+    void detailListsCustomResourceInstance() {
+      driver.navigate().to(url.toString() + "customresourcedefinitions/" + customResourceDefinitionUid());
+
+      // Custom resource instances are not watched: the embedded list is fetched on
+      // demand through the backend's dynamic-client REST endpoint, so this row
+      // proves that path end-to-end.
+      wait.until(d -> listHasRow(CUSTOM_RESOURCE_NAME));
+      assertThat(listHasRow(CUSTOM_RESOURCE_NAME))
+        .as("row for the seeded custom resource instance present in the detail page")
+        .isTrue();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/OpenShiftIT.java
+++ b/src/test/java/com/marcnuri/yakd/OpenShiftIT.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("OpenShift mode")
+public class OpenShiftIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String ROUTE_NAME = "openshift-it-route";
+  private static final String ROUTE_HOST = "openshift-it.example.com";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    // The frontend flips to OpenShift mode when the backend reports an
+    // *.openshift.io API group (served from the cluster's /apis discovery).
+    kubernetes.expect().get().withPath("/apis").andReturn(200, new APIGroupListBuilder()
+        .addToGroups(new APIGroupBuilder().withName("route.openshift.io").build())
+        .addToGroups(new APIGroupBuilder().withName("apps.openshift.io").build())
+        .build())
+      .always();
+    // The backend only subscribes its Route/DeploymentConfig watchers when the
+    // cluster's version discovery reports the resource as supported.
+    kubernetes.expect().get().withPath("/apis/route.openshift.io/v1").andReturn(200, new APIResourceListBuilder()
+        .withGroupVersion("route.openshift.io/v1")
+        .addNewResource().withName("routes").withKind("Route").withNamespaced(true).endResource()
+        .build())
+      .always();
+    kubernetes.expect().get().withPath("/apis/apps.openshift.io/v1").andReturn(200, new APIResourceListBuilder()
+        .withGroupVersion("apps.openshift.io/v1")
+        .addNewResource().withName("deploymentconfigs").withKind("DeploymentConfig").withNamespaced(true).endResource()
+        .build())
+      .always();
+    kubernetes.getClient().resources(Route.class).inNamespace(NAMESPACE)
+      .resource(route()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().resources(Route.class).inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Route route() {
+    return new RouteBuilder()
+      .withNewMetadata()
+        .withName(ROUTE_NAME)
+        .withNamespace(NAMESPACE)
+      .endMetadata()
+      .withNewSpec()
+        .withHost(ROUTE_HOST)
+        .withPath("/openshift-it")
+        .withNewTo().withKind("Service").withName("openshift-it-service").endTo()
+      .endSpec()
+      .build();
+  }
+
+  private boolean listHasRow(String text) {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(text));
+  }
+
+  @Nested
+  @DisplayName("when rendering the side bar navigation")
+  class SideBarNav {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString());
+    }
+
+    @Test
+    @DisplayName("the side bar exposes the Routes navigation item")
+    void exposesRoutesNavItem() {
+      // Conditional rendering is the behavior under test: the item only exists in
+      // the DOM at all when the frontend has detected OpenShift mode.
+      wait.until(d -> !d.findElements(By.cssSelector("[data-testid='side-bar__nav-routes']")).isEmpty());
+      assertThat(driver.findElements(By.cssSelector("[data-testid='side-bar__nav-routes']")))
+        .as("Routes side bar navigation item")
+        .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("the side bar exposes the Deployment Configs navigation item")
+    void exposesDeploymentConfigsNavItem() {
+      wait.until(d -> !d.findElements(By.cssSelector("[data-testid='side-bar__nav-deploymentconfigs']")).isEmpty());
+      assertThat(driver.findElements(By.cssSelector("[data-testid='side-bar__nav-deploymentconfigs']")))
+        .as("Deployment Configs side bar navigation item")
+        .isNotEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("when viewing the Route list and detail pages")
+  class RouteListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded route")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "routes");
+
+      wait.until(d -> listHasRow(ROUTE_NAME));
+      assertThat(listHasRow(ROUTE_NAME))
+        .as("row for the seeded route present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the list row shows the route's host")
+    void listRowShowsHost() {
+      driver.navigate().to(url.toString() + "routes");
+
+      wait.until(d -> listHasRow(ROUTE_HOST));
+      assertThat(listHasRow(ROUTE_HOST))
+        .as("seeded host shown in the route's row")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the route's host")
+    void detailRendersHost() {
+      final Route seeded = kubernetes.getClient().resources(Route.class)
+        .inNamespace(NAMESPACE).withName(ROUTE_NAME).get();
+      assertThat(seeded).as("seeded route available before navigating").isNotNull();
+
+      driver.navigate().to(url.toString() + "routes/" + seeded.getMetadata().getUid());
+
+      wait.until(d -> d.getPageSource().contains(ROUTE_HOST));
+      assertThat(driver.getPageSource())
+        .as("route detail page contents")
+        .contains(ROUTE_HOST);
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/OpenShiftIT.java
+++ b/src/test/java/com/marcnuri/yakd/OpenShiftIT.java
@@ -16,7 +16,7 @@
  */
 package com.marcnuri.yakd;
 
-import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import com.marcnuri.yakd.selenium.OpenShiftIntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.APIGroupBuilder;
 import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
 import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
@@ -47,7 +47,7 @@ import java.time.Duration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
-@TestProfile(IntegrationTestProfile.class)
+@TestProfile(OpenShiftIntegrationTestProfile.class)
 @DisplayName("OpenShift mode")
 public class OpenShiftIT {
 

--- a/src/test/java/com/marcnuri/yakd/deployment/DeploymentIT.java
+++ b/src/test/java/com/marcnuri/yakd/deployment/DeploymentIT.java
@@ -349,6 +349,20 @@ public class DeploymentIT {
     }
 
     @Test
+    @DisplayName("the side bar does not expose the OpenShift navigation items")
+    void sideBarHasNoOpenShiftNav() {
+      driver.navigate().to(url.toString() + "deployments");
+
+      // Gate on the page being fully loaded (watch synced) so the absence below
+      // cannot pass vacuously against a not-yet-rendered side bar; also guards
+      // that OpenShiftIT's /apis expectations stay on its own dedicated profile.
+      wait.until(d -> listHasDeploymentRow());
+      assertThat(driver.findElements(By.cssSelector("[data-testid='side-bar__nav-routes']")))
+        .as("Routes side bar navigation item in vanilla Kubernetes mode")
+        .isEmpty();
+    }
+
+    @Test
     @DisplayName("the detail page renders the deployment's name")
     void detailRendersName() {
       final Deployment seeded = kubernetes.getClient().apps().deployments()
@@ -395,8 +409,12 @@ public class DeploymentIT {
     }
 
     @AfterEach
-    void deleteOtherNamespaceDeployments() {
+    void deleteOtherNamespaceResources() {
       kubernetes.getClient().apps().deployments().inNamespace(OTHER_NAMESPACE).delete();
+      // Delete the seeded Namespace resources too: the mock server outlives this
+      // class, so a leaked namespace would show up in every later FilterBar.
+      kubernetes.getClient().namespaces().withName(OTHER_NAMESPACE).delete();
+      kubernetes.getClient().namespaces().withName(NAMESPACE).delete();
     }
 
     @Test

--- a/src/test/java/com/marcnuri/yakd/deployment/DeploymentIT.java
+++ b/src/test/java/com/marcnuri/yakd/deployment/DeploymentIT.java
@@ -17,6 +17,7 @@
 package com.marcnuri.yakd.deployment;
 
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
@@ -88,10 +89,14 @@ public class DeploymentIT {
   }
 
   private static Deployment deployment(String name) {
+    return deployment(name, NAMESPACE);
+  }
+
+  private static Deployment deployment(String name, String namespace) {
     return new DeploymentBuilder()
       .withNewMetadata()
         .withName(name)
-        .withNamespace(NAMESPACE)
+        .withNamespace(namespace)
         .addToLabels("mutation-marker", "before-edit")
       .endMetadata()
       .withNewSpec()
@@ -314,6 +319,142 @@ public class DeploymentIT {
       assertThat(deploymentRowShowsImage(MODIFIED_IMAGE))
         .as("deployment row reflects the server-side image change")
         .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded deployment")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "deployments");
+
+      wait.until(d -> listHasDeploymentRow());
+      assertThat(listHasDeploymentRow())
+        .as("row for the seeded deployment present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the list row shows the seeded deployment's container image")
+    void listRowShowsImage() {
+      driver.navigate().to(url.toString() + "deployments");
+
+      wait.until(d -> deploymentRowShowsImage(SEEDED_IMAGE));
+      assertThat(deploymentRowShowsImage(SEEDED_IMAGE))
+        .as("seeded container image shown in the deployment's row")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the deployment's name")
+    void detailRendersName() {
+      final Deployment seeded = kubernetes.getClient().apps().deployments()
+        .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
+      assertThat(seeded).as("seeded deployment available before navigating").isNotNull();
+
+      driver.navigate().to(url.toString() + "deployments/" + seeded.getMetadata().getUid());
+
+      wait.until(d -> d.getPageSource().contains(DEPLOYMENT_NAME));
+      assertThat(driver.getPageSource())
+        .as("detail page contents")
+        .contains(DEPLOYMENT_NAME);
+    }
+  }
+
+  @Nested
+  @DisplayName("when filtering the list by namespace")
+  class FilterByNamespace {
+
+    private static final String OTHER_NAMESPACE = "filter-other";
+    private static final String OTHER_DEPLOYMENT_NAME = "filter-other-deployment";
+    private static final By NAMESPACE_ITEM = By.cssSelector("[data-testid='filter-bar__namespace-item']");
+
+    @BeforeEach
+    void seedOtherNamespaceAndFilter() {
+      // The FilterBar lists Namespace resources streamed through the watch, so both
+      // namespaces must exist as actual resources for their dropdown items to render.
+      kubernetes.getClient().namespaces().resource(new NamespaceBuilder()
+        .withNewMetadata().withName(NAMESPACE).endMetadata().build()).createOr(NonDeletingOperation::update);
+      kubernetes.getClient().namespaces().resource(new NamespaceBuilder()
+        .withNewMetadata().withName(OTHER_NAMESPACE).endMetadata().build()).createOr(NonDeletingOperation::update);
+      kubernetes.getClient().apps().deployments().inNamespace(OTHER_NAMESPACE)
+        .resource(deployment(OTHER_DEPLOYMENT_NAME, OTHER_NAMESPACE)).createOr(NonDeletingOperation::update);
+      driver.navigate().to(url.toString() + "deployments");
+      wait.until(d -> listHasDeploymentRow() && listHasRow(OTHER_DEPLOYMENT_NAME));
+      driver.findElement(By.cssSelector("[data-testid='filter-bar__namespace'] button")).click();
+      // Item texts are only visible once the panel is open, so matching by text also
+      // waits for the dropdown to be effectively expanded.
+      wait.until(d -> d.findElements(NAMESPACE_ITEM).stream()
+        .anyMatch(item -> item.getText().equals(NAMESPACE)));
+      driver.findElements(NAMESPACE_ITEM).stream()
+        .filter(item -> item.getText().equals(NAMESPACE))
+        .findFirst().orElseThrow().click();
+    }
+
+    @AfterEach
+    void deleteOtherNamespaceDeployments() {
+      kubernetes.getClient().apps().deployments().inNamespace(OTHER_NAMESPACE).delete();
+    }
+
+    @Test
+    @DisplayName("selecting a namespace hides deployments from other namespaces")
+    void hidesOtherNamespaceRows() {
+      wait.until(d -> !listHasRow(OTHER_DEPLOYMENT_NAME));
+      assertThat(listHasRow(OTHER_DEPLOYMENT_NAME))
+        .as("row for the other-namespace deployment still present after filtering")
+        .isFalse();
+    }
+
+    @Test
+    @DisplayName("selecting a namespace keeps deployments in that namespace visible")
+    void keepsSelectedNamespaceRows() {
+      wait.until(d -> !listHasRow(OTHER_DEPLOYMENT_NAME));
+      assertThat(listHasDeploymentRow())
+        .as("row for the selected-namespace deployment present after filtering")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when searching cluster resources globally")
+  class GlobalSearch {
+
+    private static final By SEARCH_INPUT = By.cssSelector("[data-testid='search__input']");
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "search");
+      wait.until(d -> d.findElement(SEARCH_INPUT).isDisplayed());
+    }
+
+    @Test
+    @DisplayName("a query matching the seeded deployment shows its row in the results")
+    void matchingQueryShowsRow() {
+      driver.findElement(SEARCH_INPUT).sendKeys(DEPLOYMENT_NAME);
+
+      wait.until(d -> listHasDeploymentRow());
+      assertThat(listHasDeploymentRow())
+        .as("row for the seeded deployment present in the search results")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("narrowing the query to a non-matching term hides the results")
+    void nonMatchingQueryHidesRows() {
+      driver.findElement(SEARCH_INPUT).sendKeys(DEPLOYMENT_NAME);
+      // Gate on the matching row first so its later absence proves the query
+      // narrowed the results rather than the store never having synced.
+      wait.until(d -> listHasDeploymentRow());
+
+      driver.findElement(SEARCH_INPUT).sendKeys("-no-match");
+
+      wait.until(d -> !listHasDeploymentRow());
+      assertThat(listHasDeploymentRow())
+        .as("deployment row still present after narrowing the query to a non-matching term")
+        .isFalse();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/selenium/OpenShiftIntegrationTestProfile.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/OpenShiftIntegrationTestProfile.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.selenium;
+
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+
+/**
+ * Same configuration as {@link IntegrationTestProfile}, but a distinct profile class on
+ * purpose: Quarkus only restarts the application and its test resources (including the
+ * Kubernetes mock server) when the test profile changes, so OpenShift-mode tests get a
+ * dedicated boot whose mocked /apis discovery cannot leak into the vanilla-mode classes
+ * sharing the default integration profile.
+ */
+@WithSelenium
+@WithKubernetesTestServer
+public class OpenShiftIntegrationTestProfile extends IntegrationTestProfile {
+}


### PR DESCRIPTION
## Description

Implements the remaining slices of the IT coverage audit tracked in manusa/com.marcnuri.automated-tasks#1844: **L1, L2, L3, L4, X1, X2, X3** (one commit per slice group so each group's CI impact stays attributable).

| Slice | Tests |
|---|---|
| **L1** — Deployment list+detail | `DeploymentIT.ListAndDetail`: row renders, row shows image, detail renders name |
| **X1** — Namespace filter | `DeploymentIT.FilterByNamespace`: selecting a namespace hides other-namespace rows, keeps selected ones |
| **X2** — Global search | `DeploymentIT.GlobalSearch`: matching query surfaces the row; narrowing to a non-matching term hides it |
| **L2** — Cluster-scoped (Node) | `ClusterScopedResourceIT`: list row + name-keyed detail rendering seeded status fields |
| **L3** — CRD + custom resource | `ClusterScopedResourceIT`: CRD list row, detail kind, embedded CR instance via the backend dynamic-client REST path |
| **L4** — Route under OpenShift mode | `OpenShiftIT`: list row, row host, detail host — seeded route streamed through the availability-gated live watch |
| **X3** — OpenShift sidebar nav | `OpenShiftIT`: `side-bar__nav-routes` / `side-bar__nav-deploymentconfigs` only exist in OpenShift mode (plus a vanilla-mode regression test in `DeploymentIT` asserting they do not) |

### Testability hook

X2 needed a stable selector on the search box: `Textfield` now spreads additional props onto its `<input>` (placed before the controlled `value`/`onChange` so callers cannot clobber them) and `SearchPage` passes `data-testid='search__input'`. Covered by a new `Textfield` component test. Feature-specific hook, so not added to the AGENTS.md shared-hook table (same treatment as `deployment-list__restart`).

### CI cost

- All vanilla-mode classes — including the two new ones — share **one** Quarkus boot: `@QuarkusTest` only restarts on profile change, so `ClusterScopedResourceIT` adds **no** new boot.
- `OpenShiftIT` runs on a dedicated `OpenShiftIntegrationTestProfile` (**the only +1 boot**): its always-on `/apis` discovery mock would otherwise leak into vanilla-mode classes sharing the boot and silently flip the whole UI to OpenShift mode. A vanilla-mode regression test in `DeploymentIT` guards this. Measured locally: 31.7s → 31.8s total it-tests phase — a same-JVM profile restart skips augmentation, so the extra boot is ~free.

### Verification

- `make test-it`: 37 tests (19 existing + 18 new), 0 failures — 2 Quarkus boots, 2 isolated mock servers
- `make test-frontend`: 165 passed
- `make lint` / `make fmt-check` / `make license-check`: clean

Refs manusa/com.marcnuri.automated-tasks#1844 — on merge, tick L1–L4 and X1–X3 in the slice checklist.