### PR TITLE
test: add backend unit tests for Selenium-unreachable behaviors

### DIFF
--- a/src/test/java/com/marcnuri/yakd/KubernetesClientExceptionMapperTest.java
+++ b/src/test/java/com/marcnuri/yakd/KubernetesClientExceptionMapperTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created on 2026-06-12
+ */
+package com.marcnuri.yakd;
+
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@WithKubernetesTestServer
+class KubernetesClientExceptionMapperTest {
+
+  private final KubernetesClientExceptionMapper mapper = new KubernetesClientExceptionMapper();
+
+  @Inject
+  KubernetesClient kubernetesClient;
+  @KubernetesTestServer
+  KubernetesServer mockServer;
+
+  @Nested
+  @DisplayName("toResponse - status code")
+  class StatusCode {
+
+    @Test
+    @DisplayName("propagates an in-range Kubernetes status code")
+    void inRange() {
+      assertThat(mapper.toResponse(new KubernetesClientException("not found", 404, null)).getStatus())
+        .isEqualTo(404);
+    }
+
+    @Test
+    @DisplayName("clamps a below-range code to 500")
+    void belowRange() {
+      assertThat(mapper.toResponse(new KubernetesClientException("boom", 0, null)).getStatus())
+        .isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("clamps an above-range code to 500")
+    void aboveRange() {
+      assertThat(mapper.toResponse(new KubernetesClientException("boom", 600, null)).getStatus())
+        .isEqualTo(500);
+    }
+  }
+
+  @Nested
+  @DisplayName("toResponse - YAKD-Exception-Type header")
+  class ExceptionTypeHeader {
+
+    @Test
+    @DisplayName("uses the cause's class name when present")
+    void fromCause() {
+      assertThat(mapper.toResponse(new KubernetesClientException("io", new IOException("io")))
+        .getHeaderString("YAKD-Exception-Type"))
+        .isEqualTo(IOException.class.getName());
+    }
+
+    @Test
+    @DisplayName("defaults to KubernetesClientException when there is no cause")
+    void withoutCause() {
+      assertThat(mapper.toResponse(new KubernetesClientException("plain", 404, null))
+        .getHeaderString("YAKD-Exception-Type"))
+        .isEqualTo(KubernetesClientException.class.getName());
+    }
+  }
+
+  @Nested
+  @DisplayName("toResponse - entity")
+  class Entity {
+
+    @Test
+    @DisplayName("uses the status message when a status is present")
+    void fromStatusMessage() {
+      assertThat(mapper.toResponse(new KubernetesClientException(
+        "fallback", 404, new StatusBuilder().withCode(404).withMessage("status says boom").build())).getEntity())
+        .isEqualTo("status says boom");
+    }
+
+    @Test
+    @DisplayName("falls back to the exception message when there is no status")
+    void fromExceptionMessage() {
+      assertThat(mapper.toResponse(new KubernetesClientException("plain message", 404, null)).getEntity())
+        .isEqualTo("plain message");
+    }
+
+    @Test
+    @DisplayName("is rendered as plain text")
+    void plainText() {
+      assertThat(mapper.toResponse(new KubernetesClientException("boom", 404, null)).getMediaType())
+        .isEqualTo(MediaType.TEXT_PLAIN_TYPE);
+    }
+  }
+
+  @Nested
+  @DisplayName("end-to-end propagation through the JAX-RS pipeline")
+  class EndToEnd {
+
+    @AfterEach
+    void cleanUp() {
+      kubernetesClient.secrets().inNamespace(kubernetesClient.getConfiguration().getNamespace()).delete();
+    }
+
+    @Test
+    @DisplayName("a downstream 404 surfaces as a 404 response")
+    void propagates404() {
+      final var namespace = kubernetesClient.getConfiguration().getNamespace();
+      kubernetesClient.secrets().inNamespace(namespace)
+        .resource(new SecretBuilder().withNewMetadata().withName("gone").endMetadata().build()).create();
+      mockServer.expect().put().withPath("/api/v1/namespaces/" + namespace + "/secrets/gone")
+        .andReturn(404, new StatusBuilder().withCode(404).withMessage("secrets \"gone\" not found").build())
+        .once();
+      given().contentType("application/json")
+        .body(new SecretBuilder().withNewMetadata().withName("gone").endMetadata().build())
+        .when().put("/api/v1/secrets/" + namespace + "/gone")
+        .then().statusCode(404);
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/RbacFallbackTest.java
+++ b/src/test/java/com/marcnuri/yakd/RbacFallbackTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created on 2026-06-12
+ */
+package com.marcnuri.yakd;
+
+import com.marcnuri.yakd.secrets.SecretService;
+import com.marcnuri.yakd.watch.WatchEvent;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import jakarta.inject.Inject;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@WithKubernetesTestServer
+class RbacFallbackTest {
+
+  private static final String OTHER_NAMESPACE = "yakd-rbac-other";
+
+  @Inject
+  KubernetesClient kubernetesClient;
+  @Inject
+  SecretService secretService;
+  @KubernetesTestServer
+  KubernetesServer mockServer;
+
+  String configuredNamespace;
+
+  @BeforeEach
+  void setUp() {
+    configuredNamespace = kubernetesClient.getConfiguration().getNamespace();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    kubernetesClient.secrets().inNamespace(configuredNamespace).delete();
+    kubernetesClient.secrets().inNamespace(OTHER_NAMESPACE).delete();
+    kubernetesClient.configMaps().inNamespace(configuredNamespace).delete();
+    kubernetesClient.configMaps().inNamespace(OTHER_NAMESPACE).delete();
+  }
+
+  private static Status forbidden() {
+    return new StatusBuilder().withStatus("Failure").withReason("Forbidden").withCode(403)
+      .withMessage("cluster-wide access is denied").build();
+  }
+
+  @Nested
+  @DisplayName("get() falls back to the configured namespace when cluster-wide access is denied")
+  class GetFallback {
+
+    @Test
+    @DisplayName("Secret get() returns only the configured namespace's secrets")
+    void secretGetFallsBack() {
+      mockServer.expect().get().withPath("/api/v1/secrets").andReturn(403, forbidden()).once();
+      kubernetesClient.secrets().inNamespace(configuredNamespace)
+        .resource(new SecretBuilder().withNewMetadata().withName("rbac-configured").endMetadata().build()).create();
+      kubernetesClient.secrets().inNamespace(OTHER_NAMESPACE)
+        .resource(new SecretBuilder().withNewMetadata().withName("rbac-other").endMetadata().build()).create();
+      final var names = when().get("/api/v1/secrets")
+        .then().statusCode(200)
+        .extract().jsonPath().getList("metadata.name", String.class);
+      assertThat(names).contains("rbac-configured").doesNotContain("rbac-other");
+    }
+
+    @Test
+    @DisplayName("ConfigMap get() returns only the configured namespace's config maps")
+    void configMapGetFallsBack() {
+      mockServer.expect().get().withPath("/api/v1/configmaps").andReturn(403, forbidden()).once();
+      kubernetesClient.configMaps().inNamespace(configuredNamespace)
+        .resource(new ConfigMapBuilder().withNewMetadata().withName("rbac-configured").endMetadata().build()).create();
+      kubernetesClient.configMaps().inNamespace(OTHER_NAMESPACE)
+        .resource(new ConfigMapBuilder().withNewMetadata().withName("rbac-other").endMetadata().build()).create();
+      final var names = when().get("/api/v1/configmaps")
+        .then().statusCode(200)
+        .extract().jsonPath().getList("metadata.name", String.class);
+      assertThat(names).contains("rbac-configured").doesNotContain("rbac-other");
+    }
+  }
+
+  @Nested
+  @DisplayName("watch() falls back to the configured namespace when cluster-wide access is denied")
+  class WatchFallback {
+
+    @Test
+    @DisplayName("Secret watch() emits only the configured namespace's events")
+    void secretWatchFallsBack() {
+      mockServer.expect().get().withPath("/api/v1/secrets?limit=1").andReturn(403, forbidden()).once();
+      final var subscriber = AssertSubscriber.<WatchEvent<Secret>>create(Long.MAX_VALUE);
+      Multi.createFrom().<WatchEvent<Secret>>emitter(emitter -> {
+        try (var ignored = secretService.watch().subscribe(e -> {}, emitter)) {
+          // Seed the other namespace first: watch events on one connection are ordered, so a
+          // cluster-wide leak (fallback not taken) would surface "rbac-watch-other" before the
+          // awaited "rbac-watch-configured" event, making the negative assertion below meaningful.
+          kubernetesClient.secrets().inNamespace(OTHER_NAMESPACE)
+            .resource(new SecretBuilder().withNewMetadata().withName("rbac-watch-other").endMetadata().build()).create();
+          kubernetesClient.secrets().inNamespace(configuredNamespace)
+            .resource(new SecretBuilder().withNewMetadata().withName("rbac-watch-configured").endMetadata().build()).create();
+          Awaitility.await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> hasEvent(subscriber, "rbac-watch-configured"));
+        } catch (Exception e) {
+          emitter.fail(e);
+        }
+      }).subscribe().withSubscriber(subscriber);
+
+      Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        .until(() -> hasEvent(subscriber, "rbac-watch-configured"));
+
+      assertThat(subscriber.getItems())
+        .extracting(e -> e.object().getMetadata().getName())
+        .doesNotContain("rbac-watch-other");
+    }
+
+    private static boolean hasEvent(AssertSubscriber<WatchEvent<Secret>> subscriber, String name) {
+      return subscriber.getItems().stream()
+        .anyMatch(e -> name.equals(e.object().getMetadata().getName()));
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/customresources/CustomResourceRoutingTest.java
+++ b/src/test/java/com/marcnuri/yakd/customresources/CustomResourceRoutingTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created on 2026-06-12
+ */
+package com.marcnuri.yakd.customresources;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@WithKubernetesTestServer
+class CustomResourceRoutingTest {
+
+  private static final String GROUP = "yakd.example.com";
+  private static final String VERSION = "v1";
+  private static final String PLURAL = "widgets";
+  private static final String NAMESPACE = "widget-namespace";
+  private static final String BASE = "/api/v1/customresources/" + GROUP + "/" + VERSION + "/" + PLURAL;
+
+  @Inject
+  KubernetesClient kubernetesClient;
+
+  @AfterEach
+  void cleanUp() {
+    for (final String name : new String[] {"to-delete", "to-update"}) {
+      kubernetesClient.genericKubernetesResources(clusterContext()).withName(name).delete();
+      kubernetesClient.genericKubernetesResources(namespacedContext()).inNamespace(NAMESPACE).withName(name).delete();
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE resolves to the correct scope")
+  class Delete {
+
+    @Test
+    @DisplayName("namespaced path deletes the namespaced custom resource")
+    void namespaced() {
+      kubernetesClient.genericKubernetesResources(namespacedContext()).inNamespace(NAMESPACE)
+        .resource(customResource("to-delete")).create();
+      when().delete(BASE + "/namespaces/" + NAMESPACE + "/to-delete")
+        .then().statusCode(204);
+      assertThat(kubernetesClient.genericKubernetesResources(namespacedContext()).inNamespace(NAMESPACE)
+        .withName("to-delete").get()).isNull();
+    }
+
+    @Test
+    @DisplayName("cluster-scoped path deletes the cluster-scoped custom resource")
+    void clusterScoped() {
+      kubernetesClient.genericKubernetesResources(clusterContext())
+        .resource(customResource("to-delete")).create();
+      when().delete(BASE + "/to-delete")
+        .then().statusCode(204);
+      assertThat(kubernetesClient.genericKubernetesResources(clusterContext())
+        .withName("to-delete").get()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT resolves to the correct scope")
+  class Update {
+
+    @Test
+    @DisplayName("namespaced path updates the namespaced custom resource")
+    void namespaced() {
+      final var created = kubernetesClient.genericKubernetesResources(namespacedContext()).inNamespace(NAMESPACE)
+        .resource(customResource("to-update")).create();
+      given().contentType("application/json")
+        .body(new GenericKubernetesResourceBuilder(created)
+          .editMetadata().addToAnnotations("updated", "true").endMetadata().build())
+        .when().put(BASE + "/namespaces/" + NAMESPACE + "/to-update")
+        .then().statusCode(200);
+      assertThat(kubernetesClient.genericKubernetesResources(namespacedContext()).inNamespace(NAMESPACE)
+        .withName("to-update").get())
+        .extracting(r -> r.getMetadata().getAnnotations().get("updated"))
+        .isEqualTo("true");
+    }
+
+    @Test
+    @DisplayName("cluster-scoped path updates the cluster-scoped custom resource")
+    void clusterScoped() {
+      final var created = kubernetesClient.genericKubernetesResources(clusterContext())
+        .resource(customResource("to-update")).create();
+      given().contentType("application/json")
+        .body(new GenericKubernetesResourceBuilder(created)
+          .editMetadata().addToAnnotations("updated", "true").endMetadata().build())
+        .when().put(BASE + "/to-update")
+        .then().statusCode(200);
+      assertThat(kubernetesClient.genericKubernetesResources(clusterContext())
+        .withName("to-update").get())
+        .extracting(r -> r.getMetadata().getAnnotations().get("updated"))
+        .isEqualTo("true");
+    }
+  }
+
+  private static GenericKubernetesResource customResource(String name) {
+    return new GenericKubernetesResourceBuilder()
+      .withApiVersion(GROUP + "/" + VERSION)
+      .withKind("Widget")
+      .withNewMetadata().withName(name).endMetadata()
+      .build();
+  }
+
+  private static ResourceDefinitionContext clusterContext() {
+    return new ResourceDefinitionContext.Builder()
+      .withNamespaced(false).withGroup(GROUP).withVersion(VERSION).withPlural(PLURAL).build();
+  }
+
+  private static ResourceDefinitionContext namespacedContext() {
+    return new ResourceDefinitionContext.Builder()
+      .withNamespaced(true).withGroup(GROUP).withVersion(VERSION).withPlural(PLURAL).build();
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/fabric8/ClientUtilTest.java
+++ b/src/test/java/com/marcnuri/yakd/fabric8/ClientUtilTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created on 2026-06-12
+ */
+package com.marcnuri.yakd.fabric8;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static com.marcnuri.yakd.fabric8.ClientUtil.tryInOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ClientUtilTest {
+
+  @Test
+  @DisplayName("tryInOrder - returns the first supplier's value when it succeeds")
+  void returnsFirstSuccessfulValue() {
+    final Supplier<String> first = () -> "first";
+    final Supplier<String> second = () -> "second";
+    assertThat(tryInOrder(first, second)).isEqualTo("first");
+  }
+
+  @Test
+  @DisplayName("tryInOrder - falls back to the next supplier when the previous one is denied")
+  void fallsBackOnKubernetesClientException() {
+    final Supplier<String> denied = () -> {
+      throw new KubernetesClientException("Forbidden");
+    };
+    final Supplier<String> fallback = () -> "fallback";
+    assertThat(tryInOrder(denied, fallback)).isEqualTo("fallback");
+  }
+
+  @Test
+  @DisplayName("tryInOrder - throws the last exception when every supplier is denied")
+  void throwsLastExceptionWhenAllDenied() {
+    final Supplier<String> first = () -> {
+      throw new KubernetesClientException("first failure");
+    };
+    final Supplier<String> last = () -> {
+      throw new KubernetesClientException("last failure");
+    };
+    assertThatThrownBy(() -> tryInOrder(first, last))
+      .isInstanceOf(KubernetesClientException.class)
+      .hasMessage("last failure");
+  }
+}


### PR DESCRIPTION
## Summary

Adds a focused backend unit-test layer (`*Test.java`) for behavior the Selenium
IT suite (#205) cannot or should not assert, complementing the Selenium-first
testing strategy without duplicating UI-reachable coverage. **Test-only change —
no production code is modified.**

## What's covered

- **`tryInOrder` RBAC fallback** — nearly every `*Service.get()`/`watch()` tries
  `inAnyNamespace()` first and falls back to the configured namespace when
  cluster-wide access is denied. Covered generically (`ClientUtilTest`) and on
  representative resources: Secret/ConfigMap `get()` and Secret `watch()`
  (`RbacFallbackTest`).
- **CustomResource scope routing** — namespaced (`…/namespaces/{ns}/{name}`) vs
  cluster-scoped (`…/{name}`) delete and update resolve to the correct downstream
  Kubernetes API path (`CustomResourceRoutingTest`).
- **HTTP error/status contract** — `KubernetesClientExceptionMapper`: in-range
  code pass-through, out-of-range clamp to 500, `YAKD-Exception-Type` header, and
  `Status` message fallback, plus an end-to-end propagation through the JAX-RS
  pipeline (`KubernetesClientExceptionMapperTest`).

## Notes

- Black-box only (no mocks): real `Supplier` lambdas for the generic helper and
  the Fabric8 mock server for the rest.
- Tests are self-proving via discriminator data (an extra resource in another
  namespace; correctly/incorrectly scoped instances), so a regression in the
  behavior under test fails the assertion.
- One assertion per test; all seeded resources cleaned up in `@AfterEach`;
  `expect()` expectations scoped with `.once()` to avoid leaking across the
  shared Quarkus boot.

## Verification

- `make test-unit` — `Tests run: 84, Failures: 0, Errors: 0` (19 new)
- `make license-check` — all source files have the required header

Closes #141