### PR TITLE
test: add list/detail, delete, edit-save ITs for 16 resource types

### DIFF
--- a/src/test/java/com/marcnuri/yakd/clusterrolebindings/ClusterRoleBindingIT.java
+++ b/src/test/java/com/marcnuri/yakd/clusterrolebindings/ClusterRoleBindingIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.clusterrolebindings;
+
+import com.marcnuri.yakd.selenium.RbacIntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(RbacIntegrationTestProfile.class)
+@DisplayName("ClusterRoleBinding")
+public class ClusterRoleBindingIT {
+
+  private static final String CLUSTER_ROLE_BINDING_NAME = "it-cluster-role-binding";
+  private static final String DETAIL_MARKER = "cluster-role-binding-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    // The ClusterRoleBinding watcher only subscribes when the cluster's discovery reports
+    // clusterrolebindings as supported; the CRUD mock does not advertise them by default.
+    kubernetes.expect().get().withPath("/apis/rbac.authorization.k8s.io/v1")
+      .andReturn(200, new APIResourceListBuilder()
+        .withGroupVersion("rbac.authorization.k8s.io/v1")
+        .addNewResource().withName("clusterroles").withKind("ClusterRole").withNamespaced(false).endResource()
+        .addNewResource().withName("clusterrolebindings").withKind("ClusterRoleBinding").withNamespaced(false).endResource()
+        .addNewResource().withName("roles").withKind("Role").withNamespaced(true).endResource()
+        .addNewResource().withName("rolebindings").withKind("RoleBinding").withNamespaced(true).endResource()
+        .build())
+      .always();
+    kubernetes.getClient().rbac().clusterRoleBindings()
+      .resource(clusterRoleBinding()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().rbac().clusterRoleBindings().withName(CLUSTER_ROLE_BINDING_NAME).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static ClusterRoleBinding clusterRoleBinding() {
+    return new ClusterRoleBindingBuilder()
+      .withNewMetadata()
+        .withName(CLUSTER_ROLE_BINDING_NAME)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .withNewRoleRef()
+        .withApiGroup("rbac.authorization.k8s.io").withKind("ClusterRole").withName("it-cluster-role")
+      .endRoleRef()
+      .addNewSubject()
+        .withApiGroup("rbac.authorization.k8s.io").withKind("User").withName("it-user")
+      .endSubject()
+      .build();
+  }
+
+  private boolean listHasClusterRoleBindingRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(CLUSTER_ROLE_BINDING_NAME));
+  }
+
+  private String seededUid() {
+    final ClusterRoleBinding seeded = kubernetes.getClient().rbac().clusterRoleBindings()
+      .withName(CLUSTER_ROLE_BINDING_NAME).get();
+    assertThat(seeded).as("seeded cluster role binding available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final ClusterRoleBinding clusterRoleBinding = kubernetes.getClient().rbac().clusterRoleBindings()
+      .withName(CLUSTER_ROLE_BINDING_NAME).get();
+    if (clusterRoleBinding == null || clusterRoleBinding.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return clusterRoleBinding.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded cluster role binding")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "clusterrolebindings");
+
+      wait.until(d -> listHasClusterRoleBindingRow());
+      assertThat(listHasClusterRoleBindingRow())
+        .as("row for the seeded cluster role binding present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the cluster role binding's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "clusterrolebindings/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("cluster role binding detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "clusterrolebindings");
+      wait.until(d -> listHasClusterRoleBindingRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the cluster role binding's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(CLUSTER_ROLE_BINDING_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasClusterRoleBindingRow());
+      assertThat(listHasClusterRoleBindingRow())
+        .as("cluster role binding row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "clusterrolebindings/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted cluster role binding")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/clusterroles/ClusterRoleIT.java
+++ b/src/test/java/com/marcnuri/yakd/clusterroles/ClusterRoleIT.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.clusterroles;
+
+import com.marcnuri.yakd.selenium.RbacIntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(RbacIntegrationTestProfile.class)
+@DisplayName("ClusterRole")
+public class ClusterRoleIT {
+
+  private static final String CLUSTER_ROLE_NAME = "it-cluster-role";
+  private static final String DETAIL_MARKER = "cluster-role-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    // The ClusterRole watcher only subscribes when the cluster's discovery reports
+    // clusterroles as supported; the CRUD mock does not advertise them by default.
+    kubernetes.expect().get().withPath("/apis/rbac.authorization.k8s.io/v1")
+      .andReturn(200, new APIResourceListBuilder()
+        .withGroupVersion("rbac.authorization.k8s.io/v1")
+        .addNewResource().withName("clusterroles").withKind("ClusterRole").withNamespaced(false).endResource()
+        .addNewResource().withName("clusterrolebindings").withKind("ClusterRoleBinding").withNamespaced(false).endResource()
+        .addNewResource().withName("roles").withKind("Role").withNamespaced(true).endResource()
+        .addNewResource().withName("rolebindings").withKind("RoleBinding").withNamespaced(true).endResource()
+        .build())
+      .always();
+    kubernetes.getClient().rbac().clusterRoles()
+      .resource(clusterRole()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().rbac().clusterRoles().withName(CLUSTER_ROLE_NAME).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static ClusterRole clusterRole() {
+    return new ClusterRoleBuilder()
+      .withNewMetadata()
+        .withName(CLUSTER_ROLE_NAME)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .addNewRule()
+        .withApiGroups("").withResources("pods").withVerbs("get", "list", "watch")
+      .endRule()
+      .build();
+  }
+
+  private boolean listHasClusterRoleRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(CLUSTER_ROLE_NAME));
+  }
+
+  private String seededUid() {
+    final ClusterRole seeded = kubernetes.getClient().rbac().clusterRoles()
+      .withName(CLUSTER_ROLE_NAME).get();
+    assertThat(seeded).as("seeded cluster role available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final ClusterRole clusterRole = kubernetes.getClient().rbac().clusterRoles()
+      .withName(CLUSTER_ROLE_NAME).get();
+    if (clusterRole == null || clusterRole.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return clusterRole.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded cluster role")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "clusterroles");
+
+      wait.until(d -> listHasClusterRoleRow());
+      assertThat(listHasClusterRoleRow())
+        .as("row for the seeded cluster role present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the cluster role's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "clusterroles/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("cluster role detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "clusterroles");
+      wait.until(d -> listHasClusterRoleRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the cluster role's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(CLUSTER_ROLE_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasClusterRoleRow());
+      assertThat(listHasClusterRoleRow())
+        .as("cluster role row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "clusterroles/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted cluster role")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/configmaps/ConfigMapIT.java
+++ b/src/test/java/com/marcnuri/yakd/configmaps/ConfigMapIT.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.configmaps;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("ConfigMap")
+public class ConfigMapIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String CONFIG_MAP_NAME = "it-config-map";
+  private static final String DETAIL_MARKER = "config-map-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().configMaps().inNamespace(NAMESPACE)
+      .resource(configMap()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().configMaps().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static ConfigMap configMap() {
+    return new ConfigMapBuilder()
+      .withNewMetadata()
+        .withName(CONFIG_MAP_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .addToData("detail-key", DETAIL_MARKER)
+      .build();
+  }
+
+  private boolean listHasConfigMapRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(CONFIG_MAP_NAME));
+  }
+
+  private String seededUid() {
+    final ConfigMap seeded = kubernetes.getClient().configMaps()
+      .inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).get();
+    assertThat(seeded).as("seeded config map available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final ConfigMap configMap = kubernetes.getClient().configMaps()
+      .inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).get();
+    if (configMap == null || configMap.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return configMap.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded config map")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "configmaps");
+
+      wait.until(d -> listHasConfigMapRow());
+      assertThat(listHasConfigMapRow())
+        .as("row for the seeded config map present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the config map's data value")
+    void detailRendersDataValue() {
+      driver.navigate().to(url.toString() + "configmaps/" + seededUid());
+
+      // The data value can only come from the seeded resource's data map, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("config map detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "configmaps");
+      wait.until(d -> listHasConfigMapRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the config map's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(CONFIG_MAP_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasConfigMapRow());
+      assertThat(listHasConfigMapRow())
+        .as("config map row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "configmaps/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted config map")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/endpoints/EndpointIT.java
+++ b/src/test/java/com/marcnuri/yakd/endpoints/EndpointIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.endpoints;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.EndpointsBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Endpoint")
+public class EndpointIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String ENDPOINT_NAME = "it-endpoint";
+  private static final String ADDRESS_IP = "10.40.50.60";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().endpoints().inNamespace(NAMESPACE)
+      .resource(endpoint()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().endpoints().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Endpoints endpoint() {
+    return new EndpointsBuilder()
+      .withNewMetadata()
+        .withName(ENDPOINT_NAME)
+        .withNamespace(NAMESPACE)
+      .endMetadata()
+      .addNewSubset()
+        .addNewAddress()
+          .withIp(ADDRESS_IP)
+          // The detail page's Target component dereferences address.targetRef.kind without a
+          // null guard, so the address must carry a targetRef or the detail render would throw.
+          .withNewTargetRef()
+            .withKind("Pod").withName("it-target-pod").withUid("it-target-pod-uid")
+          .endTargetRef()
+        .endAddress()
+        .addNewPort().withName("http").withPort(8080).withProtocol("TCP").endPort()
+      .endSubset()
+      .build();
+  }
+
+  private boolean listHasEndpointRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(ENDPOINT_NAME));
+  }
+
+  private String seededUid() {
+    final Endpoints seeded = kubernetes.getClient().endpoints()
+      .inNamespace(NAMESPACE).withName(ENDPOINT_NAME).get();
+    assertThat(seeded).as("seeded endpoint available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded endpoint")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "endpoints");
+
+      wait.until(d -> listHasEndpointRow());
+      assertThat(listHasEndpointRow())
+        .as("row for the seeded endpoint present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the endpoint's subset address")
+    void detailRendersAddress() {
+      driver.navigate().to(url.toString() + "endpoints/" + seededUid());
+
+      // The address IP can only come from the seeded resource's subsets, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(ADDRESS_IP));
+      assertThat(driver.getPageSource())
+        .as("endpoint detail page contents")
+        .contains(ADDRESS_IP);
+    }
+  }
+
+  // No EditAndSave group: the Endpoints detail page is rendered with editable=false
+  // (the resource exposes no update endpoint), so there is no YAML editor to exercise.
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "endpoints");
+      wait.until(d -> listHasEndpointRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the endpoint's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(ENDPOINT_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasEndpointRow());
+      assertThat(listHasEndpointRow())
+        .as("endpoint row still present after delete")
+        .isFalse();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/horizontalpodautoscalers/HorizontalPodAutoscalerIT.java
+++ b/src/test/java/com/marcnuri/yakd/horizontalpodautoscalers/HorizontalPodAutoscalerIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.horizontalpodautoscalers;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscaler;
+import io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("HorizontalPodAutoscaler")
+public class HorizontalPodAutoscalerIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String HPA_NAME = "it-horizontal-pod-autoscaler";
+  private static final String DETAIL_MARKER = "horizontal-pod-autoscaler-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().autoscaling().v1().horizontalPodAutoscalers().inNamespace(NAMESPACE)
+      .resource(horizontalPodAutoscaler()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().autoscaling().v1().horizontalPodAutoscalers().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static HorizontalPodAutoscaler horizontalPodAutoscaler() {
+    return new HorizontalPodAutoscalerBuilder()
+      .withNewMetadata()
+        .withName(HPA_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .withNewSpec()
+        .withNewScaleTargetRef()
+          .withApiVersion("apps/v1").withKind("Deployment").withName("it-target")
+        .endScaleTargetRef()
+        .withMaxReplicas(5)
+      .endSpec()
+      .build();
+  }
+
+  private boolean listHasHorizontalPodAutoscalerRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(HPA_NAME));
+  }
+
+  private String seededUid() {
+    final HorizontalPodAutoscaler seeded = kubernetes.getClient().autoscaling().v1()
+      .horizontalPodAutoscalers().inNamespace(NAMESPACE).withName(HPA_NAME).get();
+    assertThat(seeded).as("seeded horizontal pod autoscaler available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final HorizontalPodAutoscaler horizontalPodAutoscaler = kubernetes.getClient().autoscaling().v1()
+      .horizontalPodAutoscalers().inNamespace(NAMESPACE).withName(HPA_NAME).get();
+    if (horizontalPodAutoscaler == null || horizontalPodAutoscaler.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return horizontalPodAutoscaler.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded horizontal pod autoscaler")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "horizontalpodautoscalers");
+
+      wait.until(d -> listHasHorizontalPodAutoscalerRow());
+      assertThat(listHasHorizontalPodAutoscalerRow())
+        .as("row for the seeded horizontal pod autoscaler present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the horizontal pod autoscaler's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "horizontalpodautoscalers/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("horizontal pod autoscaler detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "horizontalpodautoscalers");
+      wait.until(d -> listHasHorizontalPodAutoscalerRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the horizontal pod autoscaler's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(HPA_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasHorizontalPodAutoscalerRow());
+      assertThat(listHasHorizontalPodAutoscalerRow())
+        .as("horizontal pod autoscaler row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "horizontalpodautoscalers/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted horizontal pod autoscaler")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/ingresses/IngressIT.java
+++ b/src/test/java/com/marcnuri/yakd/ingresses/IngressIT.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.ingresses;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Ingress")
+public class IngressIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String INGRESS_NAME = "it-ingress";
+  private static final String DETAIL_MARKER = "ingress-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().network().v1().ingresses().inNamespace(NAMESPACE)
+      .resource(ingress()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().network().v1().ingresses().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Ingress ingress() {
+    return new IngressBuilder()
+      .withNewMetadata()
+        .withName(INGRESS_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .withNewSpec()
+        .addNewRule()
+          .withHost("it-ingress.example.com")
+          .withNewHttp()
+            .addNewPath()
+              .withPath("/")
+              .withPathType("Prefix")
+              .withNewBackend()
+                .withNewService()
+                  .withName("it-service")
+                  .withNewPort().withNumber(80).endPort()
+                .endService()
+              .endBackend()
+            .endPath()
+          .endHttp()
+        .endRule()
+      .endSpec()
+      .build();
+  }
+
+  private boolean listHasIngressRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(INGRESS_NAME));
+  }
+
+  private String seededUid() {
+    final Ingress seeded = kubernetes.getClient().network().v1().ingresses()
+      .inNamespace(NAMESPACE).withName(INGRESS_NAME).get();
+    assertThat(seeded).as("seeded ingress available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final Ingress ingress = kubernetes.getClient().network().v1().ingresses()
+      .inNamespace(NAMESPACE).withName(INGRESS_NAME).get();
+    if (ingress == null || ingress.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return ingress.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded ingress")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "ingresses");
+
+      wait.until(d -> listHasIngressRow());
+      assertThat(listHasIngressRow())
+        .as("row for the seeded ingress present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the ingress's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "ingresses/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("ingress detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "ingresses");
+      wait.until(d -> listHasIngressRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the ingress's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(INGRESS_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasIngressRow());
+      assertThat(listHasIngressRow())
+        .as("ingress row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "ingresses/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted ingress")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/jobs/JobIT.java
+++ b/src/test/java/com/marcnuri/yakd/jobs/JobIT.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.jobs;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Job")
+public class JobIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String JOB_NAME = "it-job";
+  private static final String DETAIL_MARKER = "job-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().batch().v1().jobs().inNamespace(NAMESPACE)
+      .resource(job()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().batch().v1().jobs().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Job job() {
+    return new JobBuilder()
+      .withNewMetadata()
+        .withName(JOB_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .withNewSpec()
+        .withNewTemplate()
+          .withNewSpec()
+            .addNewContainer().withName("container-1").withImage("busybox").endContainer()
+            .withRestartPolicy("Never")
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .build();
+  }
+
+  private boolean listHasJobRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(JOB_NAME));
+  }
+
+  private String seededUid() {
+    final Job seeded = kubernetes.getClient().batch().v1().jobs()
+      .inNamespace(NAMESPACE).withName(JOB_NAME).get();
+    assertThat(seeded).as("seeded job available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final Job job = kubernetes.getClient().batch().v1().jobs()
+      .inNamespace(NAMESPACE).withName(JOB_NAME).get();
+    if (job == null || job.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return job.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded job")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "jobs");
+
+      wait.until(d -> listHasJobRow());
+      assertThat(listHasJobRow())
+        .as("row for the seeded job present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the job's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "jobs/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("job detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "jobs");
+      wait.until(d -> listHasJobRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the job's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(JOB_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasJobRow());
+      assertThat(listHasJobRow())
+        .as("job row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "jobs/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted job")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/namespaces/NamespaceIT.java
+++ b/src/test/java/com/marcnuri/yakd/namespaces/NamespaceIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.namespaces;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Namespace")
+public class NamespaceIT {
+
+  private static final String NAMESPACE_NAME = "it-namespace";
+  private static final String DETAIL_MARKER = "namespace-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().namespaces()
+      .resource(namespace()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().namespaces().withName(NAMESPACE_NAME).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Namespace namespace() {
+    return new NamespaceBuilder()
+      .withNewMetadata()
+        .withName(NAMESPACE_NAME)
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .build();
+  }
+
+  private boolean listHasNamespaceRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(NAMESPACE_NAME));
+  }
+
+  private String seededUid() {
+    final Namespace seeded = kubernetes.getClient().namespaces().withName(NAMESPACE_NAME).get();
+    assertThat(seeded).as("seeded namespace available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded namespace")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "namespaces");
+
+      wait.until(d -> listHasNamespaceRow());
+      assertThat(listHasNamespaceRow())
+        .as("row for the seeded namespace present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the namespace's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "namespaces/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("namespace detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  // No EditAndSave group: Namespace has no edit route and its detail page is rendered
+  // without a YAML editor, so only list/detail and delete are exercised here.
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "namespaces");
+      wait.until(d -> listHasNamespaceRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the namespace's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(NAMESPACE_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasNamespaceRow());
+      assertThat(listHasNamespaceRow())
+        .as("namespace row still present after delete")
+        .isFalse();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/persistentvolumeclaims/PersistentVolumeClaimIT.java
+++ b/src/test/java/com/marcnuri/yakd/persistentvolumeclaims/PersistentVolumeClaimIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.persistentvolumeclaims;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("PersistentVolumeClaim")
+public class PersistentVolumeClaimIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String PVC_NAME = "it-persistent-volume-claim";
+  private static final String DETAIL_MARKER = "persistent-volume-claim-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().persistentVolumeClaims().inNamespace(NAMESPACE)
+      .resource(persistentVolumeClaim()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().persistentVolumeClaims().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static PersistentVolumeClaim persistentVolumeClaim() {
+    return new PersistentVolumeClaimBuilder()
+      .withNewMetadata()
+        .withName(PVC_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .withNewSpec()
+        .withStorageClassName("it-storage-class")
+        .withAccessModes("ReadWriteOnce")
+        .withNewResources().addToRequests("storage", new Quantity("1Gi")).endResources()
+      .endSpec()
+      .build();
+  }
+
+  private boolean listHasPersistentVolumeClaimRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(PVC_NAME));
+  }
+
+  private String seededUid() {
+    final PersistentVolumeClaim seeded = kubernetes.getClient().persistentVolumeClaims()
+      .inNamespace(NAMESPACE).withName(PVC_NAME).get();
+    assertThat(seeded).as("seeded persistent volume claim available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final PersistentVolumeClaim persistentVolumeClaim = kubernetes.getClient()
+      .persistentVolumeClaims().inNamespace(NAMESPACE).withName(PVC_NAME).get();
+    if (persistentVolumeClaim == null || persistentVolumeClaim.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return persistentVolumeClaim.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded persistent volume claim")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "persistentvolumeclaims");
+
+      wait.until(d -> listHasPersistentVolumeClaimRow());
+      assertThat(listHasPersistentVolumeClaimRow())
+        .as("row for the seeded persistent volume claim present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the persistent volume claim's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "persistentvolumeclaims/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("persistent volume claim detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "persistentvolumeclaims");
+      wait.until(d -> listHasPersistentVolumeClaimRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the persistent volume claim's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(PVC_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasPersistentVolumeClaimRow());
+      assertThat(listHasPersistentVolumeClaimRow())
+        .as("persistent volume claim row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "persistentvolumeclaims/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted persistent volume claim")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/persistentvolumes/PersistentVolumeIT.java
+++ b/src/test/java/com/marcnuri/yakd/persistentvolumes/PersistentVolumeIT.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.persistentvolumes;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.PersistentVolume;
+import io.fabric8.kubernetes.api.model.PersistentVolumeBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("PersistentVolume")
+public class PersistentVolumeIT {
+
+  private static final String PV_NAME = "it-persistent-volume";
+  private static final String ADDED_PV_NAME = "watch-added-persistent-volume";
+  private static final String DETAIL_MARKER = "persistent-volume-detail-marker";
+  private static final String MODIFIED_PHASE = "Released";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().persistentVolumes()
+      .resource(persistentVolume(PV_NAME)).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().persistentVolumes().withName(PV_NAME).delete();
+    kubernetes.getClient().persistentVolumes().withName(ADDED_PV_NAME).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static PersistentVolume persistentVolume(String pvName) {
+    return new PersistentVolumeBuilder()
+      .withNewMetadata()
+        .withName(pvName)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .withNewSpec()
+        .addToCapacity("storage", new Quantity("1Gi"))
+        .withAccessModes("ReadWriteOnce")
+        .withStorageClassName("it-storage-class")
+        .withPersistentVolumeReclaimPolicy("Retain")
+        .withNewHostPath().withPath("/tmp/" + pvName).endHostPath()
+      .endSpec()
+      .withNewStatus().withPhase("Available").endStatus()
+      .build();
+  }
+
+  private boolean listHasRow(String pvName) {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(pvName));
+  }
+
+  private boolean persistentVolumeRowShowsPhase(String phase) {
+    return driver.findElements(ROW).stream()
+      .filter(row -> row.getText().contains(PV_NAME))
+      .anyMatch(row -> row.getText().contains(phase));
+  }
+
+  private String seededUid() {
+    final PersistentVolume seeded = kubernetes.getClient().persistentVolumes().withName(PV_NAME).get();
+    assertThat(seeded).as("seeded persistent volume available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final PersistentVolume persistentVolume = kubernetes.getClient().persistentVolumes()
+      .withName(PV_NAME).get();
+    if (persistentVolume == null || persistentVolume.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return persistentVolume.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded persistent volume")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "persistentvolumes");
+
+      wait.until(d -> listHasRow(PV_NAME));
+      assertThat(listHasRow(PV_NAME))
+        .as("row for the seeded persistent volume present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the persistent volume's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "persistentvolumes/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("persistent volume detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "persistentvolumes");
+      wait.until(d -> listHasRow(PV_NAME));
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the persistent volume's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(PV_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasRow(PV_NAME));
+      assertThat(listHasRow(PV_NAME))
+        .as("persistent volume row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "persistentvolumes/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted persistent volume")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+
+  @Nested
+  @DisplayName("when the server pushes live watch events")
+  class WatchLiveUpdates {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "persistentvolumes");
+      // Waiting for the seeded row guarantees the watch stream is connected and its
+      // initial sync replayed before the test mutates the cluster, so any later change
+      // can only reach the list through a live watch event.
+      wait.until(d -> listHasRow(PV_NAME));
+    }
+
+    @Test
+    @DisplayName("a persistent volume created server-side appears in the list without a refresh")
+    void createdPersistentVolumeAppears() {
+      kubernetes.getClient().persistentVolumes().resource(persistentVolume(ADDED_PV_NAME)).create();
+
+      wait.until(d -> listHasRow(ADDED_PV_NAME));
+      assertThat(listHasRow(ADDED_PV_NAME))
+        .as("row for the server-side-created persistent volume present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("a persistent volume deleted server-side disappears from the list without a refresh")
+    void deletedPersistentVolumeDisappears() {
+      kubernetes.getClient().persistentVolumes().withName(PV_NAME).delete();
+
+      wait.until(d -> !listHasRow(PV_NAME));
+      assertThat(listHasRow(PV_NAME))
+        .as("row for the server-side-deleted persistent volume still present in the list")
+        .isFalse();
+    }
+
+    @Test
+    @DisplayName("a persistent volume modified server-side updates its row in place without a refresh")
+    void modifiedPersistentVolumeUpdatesRow() {
+      kubernetes.getClient().persistentVolumes().withName(PV_NAME)
+        .edit(pv -> new PersistentVolumeBuilder(pv)
+          .editOrNewStatus().withPhase(MODIFIED_PHASE).endStatus()
+          .build());
+
+      wait.until(d -> persistentVolumeRowShowsPhase(MODIFIED_PHASE));
+      assertThat(persistentVolumeRowShowsPhase(MODIFIED_PHASE))
+        .as("persistent volume row reflects the server-side phase change")
+        .isTrue();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/replicationcontrollers/ReplicationControllerIT.java
+++ b/src/test/java/com/marcnuri/yakd/replicationcontrollers/ReplicationControllerIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.replicationcontrollers;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.ReplicationController;
+import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("ReplicationController")
+public class ReplicationControllerIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String RC_NAME = "it-replication-controller";
+  private static final String DETAIL_MARKER = "replication-controller-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().replicationControllers().inNamespace(NAMESPACE)
+      .resource(replicationController()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().replicationControllers().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static ReplicationController replicationController() {
+    return new ReplicationControllerBuilder()
+      .withNewMetadata()
+        .withName(RC_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .withNewSpec()
+        .withReplicas(1)
+        .addToSelector("app", RC_NAME)
+        .withNewTemplate()
+          .withNewMetadata().addToLabels("app", RC_NAME).endMetadata()
+          .withNewSpec()
+            .addNewContainer().withName("container-1").withImage("busybox").endContainer()
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .build();
+  }
+
+  private boolean listHasReplicationControllerRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(RC_NAME));
+  }
+
+  private String seededUid() {
+    final ReplicationController seeded = kubernetes.getClient().replicationControllers()
+      .inNamespace(NAMESPACE).withName(RC_NAME).get();
+    assertThat(seeded).as("seeded replication controller available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final ReplicationController replicationController = kubernetes.getClient()
+      .replicationControllers().inNamespace(NAMESPACE).withName(RC_NAME).get();
+    if (replicationController == null || replicationController.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return replicationController.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded replication controller")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "replicationcontrollers");
+
+      wait.until(d -> listHasReplicationControllerRow());
+      assertThat(listHasReplicationControllerRow())
+        .as("row for the seeded replication controller present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the replication controller's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "replicationcontrollers/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("replication controller detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "replicationcontrollers");
+      wait.until(d -> listHasReplicationControllerRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the replication controller's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(RC_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasReplicationControllerRow());
+      assertThat(listHasReplicationControllerRow())
+        .as("replication controller row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "replicationcontrollers/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted replication controller")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/rolebindings/RoleBindingIT.java
+++ b/src/test/java/com/marcnuri/yakd/rolebindings/RoleBindingIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.rolebindings;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("RoleBinding")
+public class RoleBindingIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String ROLE_BINDING_NAME = "it-role-binding";
+  private static final String DETAIL_MARKER = "role-binding-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().rbac().roleBindings().inNamespace(NAMESPACE)
+      .resource(roleBinding()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().rbac().roleBindings().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static RoleBinding roleBinding() {
+    return new RoleBindingBuilder()
+      .withNewMetadata()
+        .withName(ROLE_BINDING_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .withNewRoleRef()
+        .withApiGroup("rbac.authorization.k8s.io").withKind("Role").withName("it-role")
+      .endRoleRef()
+      .addNewSubject()
+        .withApiGroup("rbac.authorization.k8s.io").withKind("User").withName("it-user")
+      .endSubject()
+      .build();
+  }
+
+  private boolean listHasRoleBindingRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(ROLE_BINDING_NAME));
+  }
+
+  private String seededUid() {
+    final RoleBinding seeded = kubernetes.getClient().rbac().roleBindings()
+      .inNamespace(NAMESPACE).withName(ROLE_BINDING_NAME).get();
+    assertThat(seeded).as("seeded role binding available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final RoleBinding roleBinding = kubernetes.getClient().rbac().roleBindings()
+      .inNamespace(NAMESPACE).withName(ROLE_BINDING_NAME).get();
+    if (roleBinding == null || roleBinding.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return roleBinding.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded role binding")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "rolebindings");
+
+      wait.until(d -> listHasRoleBindingRow());
+      assertThat(listHasRoleBindingRow())
+        .as("row for the seeded role binding present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the role binding's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "rolebindings/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("role binding detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "rolebindings");
+      wait.until(d -> listHasRoleBindingRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the role binding's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(ROLE_BINDING_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasRoleBindingRow());
+      assertThat(listHasRoleBindingRow())
+        .as("role binding row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "rolebindings/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted role binding")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/roles/RoleIT.java
+++ b/src/test/java/com/marcnuri/yakd/roles/RoleIT.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.roles;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Role")
+public class RoleIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String ROLE_NAME = "it-role";
+  private static final String DETAIL_MARKER = "role-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().rbac().roles().inNamespace(NAMESPACE)
+      .resource(role()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().rbac().roles().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Role role() {
+    return new RoleBuilder()
+      .withNewMetadata()
+        .withName(ROLE_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .addNewRule()
+        .withApiGroups("").withResources("configmaps").withVerbs("get", "list")
+      .endRule()
+      .build();
+  }
+
+  private boolean listHasRoleRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(ROLE_NAME));
+  }
+
+  private String seededUid() {
+    final Role seeded = kubernetes.getClient().rbac().roles()
+      .inNamespace(NAMESPACE).withName(ROLE_NAME).get();
+    assertThat(seeded).as("seeded role available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final Role role = kubernetes.getClient().rbac().roles()
+      .inNamespace(NAMESPACE).withName(ROLE_NAME).get();
+    if (role == null || role.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return role.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded role")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "roles");
+
+      wait.until(d -> listHasRoleRow());
+      assertThat(listHasRoleRow())
+        .as("row for the seeded role present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the role's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "roles/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("role detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "roles");
+      wait.until(d -> listHasRoleRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the role's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(ROLE_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasRoleRow());
+      assertThat(listHasRoleRow())
+        .as("role row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "roles/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted role")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/secrets/SecretIT.java
+++ b/src/test/java/com/marcnuri/yakd/secrets/SecretIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.secrets;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Secret")
+public class SecretIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String SECRET_NAME = "it-secret";
+  private static final String DECODED_VALUE = "secret-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().secrets().inNamespace(NAMESPACE)
+      .resource(secret()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().secrets().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Secret secret() {
+    return new SecretBuilder()
+      .withNewMetadata()
+        .withName(SECRET_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withType("Opaque")
+      .addToData("detail-key",
+        Base64.getEncoder().encodeToString(DECODED_VALUE.getBytes(StandardCharsets.UTF_8)))
+      .build();
+  }
+
+  private boolean listHasSecretRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(SECRET_NAME));
+  }
+
+  private String seededUid() {
+    final Secret seeded = kubernetes.getClient().secrets()
+      .inNamespace(NAMESPACE).withName(SECRET_NAME).get();
+    assertThat(seeded).as("seeded secret available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final Secret secret = kubernetes.getClient().secrets()
+      .inNamespace(NAMESPACE).withName(SECRET_NAME).get();
+    if (secret == null || secret.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return secret.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded secret")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "secrets");
+
+      wait.until(d -> listHasSecretRow());
+      assertThat(listHasSecretRow())
+        .as("row for the seeded secret present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the secret's base64-decoded data value")
+    void detailRendersDecodedValue() {
+      driver.navigate().to(url.toString() + "secrets/" + seededUid());
+
+      // The page only ever shows the atob-decoded form, so the cleartext can only
+      // appear if the detail page decoded the seeded resource's base64 data value.
+      wait.until(d -> d.getPageSource().contains(DECODED_VALUE));
+      assertThat(driver.getPageSource())
+        .as("secret detail page contents")
+        .contains(DECODED_VALUE);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "secrets");
+      wait.until(d -> listHasSecretRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the secret's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(SECRET_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasSecretRow());
+      assertThat(listHasSecretRow())
+        .as("secret row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "secrets/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted secret")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/selenium/RbacIntegrationTestProfile.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/RbacIntegrationTestProfile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.selenium;
+
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+
+/**
+ * Same configuration as {@link IntegrationTestProfile}, but a distinct profile class on
+ * purpose: the cluster-scoped RBAC watchers (ClusterRole, ClusterRoleBinding) only subscribe
+ * when the cluster's discovery reports the resource as supported, so these tests seed an
+ * {@code /apis/rbac.authorization.k8s.io/v1} discovery expectation. Quarkus only restarts the
+ * application and its test resources (including the Kubernetes mock server) when the test
+ * profile changes, so that always-on discovery expectation cannot leak into the vanilla-mode
+ * classes sharing the default integration profile.
+ */
+@WithSelenium
+@WithKubernetesTestServer
+public class RbacIntegrationTestProfile extends IntegrationTestProfile {
+}

--- a/src/test/java/com/marcnuri/yakd/service/ServiceIT.java
+++ b/src/test/java/com/marcnuri/yakd/service/ServiceIT.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.service;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Service")
+public class ServiceIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String SERVICE_NAME = "it-service";
+  private static final String CLUSTER_IP = "10.20.30.40";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().services().inNamespace(NAMESPACE)
+      .resource(service()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().services().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static Service service() {
+    return new ServiceBuilder()
+      .withNewMetadata()
+        .withName(SERVICE_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewSpec()
+        .withType("ClusterIP")
+        .withClusterIP(CLUSTER_IP)
+        .addToSelector("app", SERVICE_NAME)
+        .addNewPort().withPort(80).withProtocol("TCP").endPort()
+      .endSpec()
+      .build();
+  }
+
+  private boolean listHasServiceRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(SERVICE_NAME));
+  }
+
+  private String seededUid() {
+    final Service seeded = kubernetes.getClient().services()
+      .inNamespace(NAMESPACE).withName(SERVICE_NAME).get();
+    assertThat(seeded).as("seeded service available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final Service service = kubernetes.getClient().services()
+      .inNamespace(NAMESPACE).withName(SERVICE_NAME).get();
+    if (service == null || service.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return service.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded service")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "services");
+
+      wait.until(d -> listHasServiceRow());
+      assertThat(listHasServiceRow())
+        .as("row for the seeded service present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the service's cluster IP")
+    void detailRendersClusterIp() {
+      driver.navigate().to(url.toString() + "services/" + seededUid());
+
+      // The cluster IP can only come from the seeded resource's spec, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(CLUSTER_IP));
+      assertThat(driver.getPageSource())
+        .as("service detail page contents")
+        .contains(CLUSTER_IP);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "services");
+      wait.until(d -> listHasServiceRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the service's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(SERVICE_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasServiceRow());
+      assertThat(listHasServiceRow())
+        .as("service row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "services/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted service")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/serviceaccounts/ServiceAccountIT.java
+++ b/src/test/java/com/marcnuri/yakd/serviceaccounts/ServiceAccountIT.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.serviceaccounts;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("ServiceAccount")
+public class ServiceAccountIT {
+
+  private static final String NAMESPACE = "default";
+  private static final String SERVICE_ACCOUNT_NAME = "it-service-account";
+  private static final String DETAIL_MARKER = "service-account-detail-marker";
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  Wait<WebDriver> wait;
+
+  @BeforeEach
+  void setUp() {
+    wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+    kubernetes.getClient().serviceAccounts().inNamespace(NAMESPACE)
+      .resource(serviceAccount()).createOr(NonDeletingOperation::update);
+    driver.switchTo().newWindow(WindowType.TAB);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetes.getClient().serviceAccounts().inNamespace(NAMESPACE).delete();
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  private static ServiceAccount serviceAccount() {
+    return new ServiceAccountBuilder()
+      .withNewMetadata()
+        .withName(SERVICE_ACCOUNT_NAME)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+        .addToLabels("detail-marker", DETAIL_MARKER)
+      .endMetadata()
+      .build();
+  }
+
+  private boolean listHasServiceAccountRow() {
+    return driver.findElements(ROW).stream()
+      .anyMatch(row -> row.getText().contains(SERVICE_ACCOUNT_NAME));
+  }
+
+  private String seededUid() {
+    final ServiceAccount seeded = kubernetes.getClient().serviceAccounts()
+      .inNamespace(NAMESPACE).withName(SERVICE_ACCOUNT_NAME).get();
+    assertThat(seeded).as("seeded service account available").isNotNull();
+    return seeded.getMetadata().getUid();
+  }
+
+  private String backendMarker() {
+    final ServiceAccount serviceAccount = kubernetes.getClient().serviceAccounts()
+      .inNamespace(NAMESPACE).withName(SERVICE_ACCOUNT_NAME).get();
+    if (serviceAccount == null || serviceAccount.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return serviceAccount.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    @Test
+    @DisplayName("the list renders a row for the seeded service account")
+    void listRendersSeededRow() {
+      driver.navigate().to(url.toString() + "serviceaccounts");
+
+      wait.until(d -> listHasServiceAccountRow());
+      assertThat(listHasServiceAccountRow())
+        .as("row for the seeded service account present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the service account's label")
+    void detailRendersLabel() {
+      driver.navigate().to(url.toString() + "serviceaccounts/" + seededUid());
+
+      // The label value can only come from the seeded resource's metadata, so its
+      // presence proves the detail page rendered the resource loaded via the watch.
+      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
+      assertThat(driver.getPageSource())
+        .as("service account detail page contents")
+        .contains(DETAIL_MARKER);
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "serviceaccounts");
+      wait.until(d -> listHasServiceAccountRow());
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the service account's row from the list")
+    void deleteRemovesRow() {
+      driver.findElements(ROW).stream()
+        .filter(row -> row.getText().contains(SERVICE_ACCOUNT_NAME))
+        .findFirst().orElseThrow()
+        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+
+      wait.until(d -> !listHasServiceAccountRow());
+      assertThat(listHasServiceAccountRow())
+        .as("service account row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    @BeforeEach
+    void navigate() {
+      driver.navigate().to(url.toString() + "serviceaccounts/" + seededUid() + "/edit");
+      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      ((JavascriptExecutor) driver).executeScript(
+        "const ed = document.querySelector('.ace_editor').env.editor;"
+          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
+
+      wait.until(d -> "after-edit".equals(backendMarker()));
+      assertThat(backendMarker())
+        .as("mutation-marker label on the persisted service account")
+        .isEqualTo("after-edit");
+    }
+
+    private String aceValue(JavascriptExecutor js) {
+      final Object value = js.executeScript(
+        "const e = document.querySelector('.ace_editor');"
+          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+      return value == null ? "" : value.toString();
+    }
+  }
+}


### PR DESCRIPTION
## What

Extends the Selenium IT suite (full-stack, Fabric8 MockServer) to cover 16
previously-untested Kubernetes resource types, continuing the coverage tracker
in #205.

Each resource gets, where applicable, three `@Nested` slices following the
`DeploymentIT` template:
- **list/detail** — a seeded row renders in the list; the detail page renders a
  resource-derived distinguishing field (data value, atob-decoded secret value,
  cluster IP, subset address, or a seeded label).
- **delete** — clicking the row's delete button removes it (asserted gone).
- **edit-save** — editing the YAML and saving persists the change to the backend
  (asserted against backend state).

| Resource | Slices |
|---|---|
| ConfigMap, Secret, Ingress, Job, PersistentVolumeClaim, HorizontalPodAutoscaler, ReplicationController, ServiceAccount, Service | list/detail, delete, edit-save |
| Endpoint, Namespace | list/detail, delete (no edit endpoint) |
| ClusterRole, ClusterRoleBinding, Role, RoleBinding | list/detail, delete, edit-save |
| PersistentVolume | list/detail, delete, edit-save, **live watch** (added/modified/deleted) |

## Notes

- `ClusterRole`/`ClusterRoleBinding` watches gate on `kubernetesClient.supports(...)`
  API discovery, which the CRUD mock doesn't advertise. They run on a new
  `RbacIntegrationTestProfile` that seeds an `/apis/rbac.authorization.k8s.io/v1`
  discovery expectation, isolated on its own profile so it can't flip vanilla-mode
  classes (same rationale as `OpenShiftIntegrationTestProfile`).
- Black-box only (no mocks of app internals), one assertion per test, all selectors
  via shared `data-testid` hooks. Cluster-scoped seeds are cleaned up by name in
  `@AfterEach` since the mock outlives each class.

## Verification

- `make test-it` — **102 tests, 0 failures, 0 errors** (65 new + existing suite,
  incl. `OpenShiftIT`, confirming no cross-profile leakage).
- `make license-check` — all source files carry the Apache header.

## Out of scope (remaining in #205)

DaemonSet/StatefulSet/DeploymentConfig restart+scale, CronJob trigger, ReplicaSet,
Pod metrics, Node/CRD/CustomResource/Route matrix completion, and a namespaced
watch slice — to follow in subsequent PRs.