### PR TITLE
test: extract shared scaffold for per-resource Selenium ITs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,20 @@ UI elements that tests need to find are marked with `data-testid`. Prefer `data-
 | `filter-bar__namespace` / `filter-bar__all-namespaces` / `filter-bar__namespace-item` | namespace filter |
 | `side-bar__nav-<route>` | sidebar nav link (e.g. `side-bar__nav-deployments`) |
 
+### Shared per-resource IT scaffold
+
+Most per-resource ITs extend **`AbstractResourceIT<T>`** and reuse **`ResourceUi`** (both in `src/test/java/com/marcnuri/yakd/selenium/`) so each file declares only what is resource-specific. The base owns the injected `WebDriver`/`KubernetesServer`/URL, a per-test isolated browser tab, the tuned `FluentWait`, and scope-agnostic backend helpers (`seed`/`seededUid`/`label` via fabric8's `client.resource(obj)`, which keys off the object's own metadata and so serves namespaced *and* cluster-scoped types alike). It declares **no** `@Nested`/`@Test` — every test stays visible in the subclass so the file reads as a spec.
+
+To add one: `class FooIT extends AbstractResourceIT<Foo>` with `@QuarkusTest @TestProfile(...) @DisplayName("Foo")`, a `super("<route>")` constructor, and one `resource(String name)` builder. Each `@Nested` group seeds a distinctly-named resource via `seed("to-view")` / `seed("to-delete")` / `seed("to-edit")` and calls the inherited delegates: `openList()`/`openDetail(uid)`/`openEditor(uid)`/`open(path)`, `awaitRow`/`awaitNoRow`/`hasRow`/`rowShows`/`deleteRow`, `awaitPageContains`/`pageContains`, `awaitEditorContains`/`editorReplace`/`save`, `seededUid(name)`/`label(name,key)`, and `await(BooleanSupplier)`. See `ConfigMapIT` for the canonical triad.
+
+Conventions:
+- **No-edit resources** (`Endpoint`, `Namespace`) simply omit the `EditAndSave` group — there is nothing to disable.
+- **Resource-specific behavior** (scale carets, the cronjob suspend toggle, namespace filter, global search) goes in extra `@Nested` groups that drive bespoke elements through the inherited `protected WebDriver driver` (see `DeploymentIT`, `CronJobMutationIT`).
+- **Cluster-scoped discovery**: `ClusterRole`/`ClusterRoleBinding` call `RbacDiscovery.advertise(kubernetes)` in a `@BeforeEach`; OpenShift ITs call `OpenShiftDiscovery.advertise(kubernetes)` and run on `OpenShiftIntegrationTestProfile` (its always-on discovery must not leak — see the boot/isolation note above).
+- **Multi-resource ITs** (`ClusterScopedResourceIT` — two types in one class) reuse `ResourceUi` by composition instead of extending the single-type base.
+- **Per-test naming & isolation**: each group seeds `<route>-<random>-<suffix>`, so no two tests share backend state and the base `@AfterEach` deletes exactly what it seeded. That independence is also the prerequisite for a possible future experiment running a class's tests concurrently — note that actually enabling `@Execution(CONCURRENT)` would additionally need a WebDriver per test/thread, since the injected one is shared and Selenium drivers are not thread-safe.
+- Genuinely page-specific ITs that don't follow the resource list/detail/edit shape stay standalone (`HomeIT` dashboard; `PodExecIT`/`PodLogsIT` terminal & log streaming).
+
 ### Frontend tests (Vitest)
 
 Component tests render via `renderToString` from `react-dom/server` and parse with `parseHtml`. Stores come from `createTestStore` (both in `src/test-utils/`). WebSocket tests use the custom `ws-test-server.js` harness. Nested `describe` groups per concern, one assertion per test:

--- a/src/test/java/com/marcnuri/yakd/ClusterScopedResourceIT.java
+++ b/src/test/java/com/marcnuri/yakd/ClusterScopedResourceIT.java
@@ -17,6 +17,7 @@
 package com.marcnuri.yakd;
 
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import com.marcnuri.yakd.selenium.ResourceUi;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeBuilder;
@@ -35,25 +36,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
 
 import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// Two distinct resource types are exercised in one class, so this reuses the ResourceUi plumbing
+// by composition rather than extending the single-type AbstractResourceIT.
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Cluster-scoped resources")
 public class ClusterScopedResourceIT {
-
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
   @KubernetesTestServer
   KubernetesServer kubernetes;
@@ -61,27 +55,16 @@ public class ClusterScopedResourceIT {
   @TestHTTPResource
   URL url;
   WebDriver driver;
-  Wait<WebDriver> wait;
+  ResourceUi ui;
 
   @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    driver.switchTo().newWindow(WindowType.TAB);
+  void openTab() {
+    ui = ResourceUi.openTab(driver, url);
   }
 
   @AfterEach
-  void tearDown() {
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private boolean listHasRow(String text) {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(text));
+  void closeTab() {
+    ui.closeTab();
   }
 
   @Nested
@@ -126,10 +109,10 @@ public class ClusterScopedResourceIT {
     @Test
     @DisplayName("the list renders a row for the seeded node")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "nodes");
+      ui.openList("nodes");
 
-      wait.until(d -> listHasRow(NODE_NAME));
-      assertThat(listHasRow(NODE_NAME))
+      ui.await(() -> ui.hasRow(NODE_NAME));
+      assertThat(ui.hasRow(NODE_NAME))
         .as("row for the seeded node present in the list")
         .isTrue();
     }
@@ -137,14 +120,14 @@ public class ClusterScopedResourceIT {
     @Test
     @DisplayName("the name-keyed detail page renders the node's kubelet version")
     void detailRendersKubeletVersion() {
-      driver.navigate().to(url.toString() + "nodes/" + NODE_NAME);
+      ui.openDetail("nodes", NODE_NAME);
 
       // The kubelet version can only come from the seeded node's status, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(KUBELET_VERSION));
-      assertThat(driver.getPageSource())
+      ui.await(() -> ui.pageContains(KUBELET_VERSION));
+      assertThat(ui.pageContains(KUBELET_VERSION))
         .as("node detail page contents")
-        .contains(KUBELET_VERSION);
+        .isTrue();
     }
   }
 
@@ -208,10 +191,10 @@ public class ClusterScopedResourceIT {
     @Test
     @DisplayName("the list renders a row for the seeded custom resource definition")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "customresourcedefinitions");
+      ui.openList("customresourcedefinitions");
 
-      wait.until(d -> listHasRow(CRD_NAME));
-      assertThat(listHasRow(CRD_NAME))
+      ui.await(() -> ui.hasRow(CRD_NAME));
+      assertThat(ui.hasRow(CRD_NAME))
         .as("row for the seeded custom resource definition present in the list")
         .isTrue();
     }
@@ -219,26 +202,26 @@ public class ClusterScopedResourceIT {
     @Test
     @DisplayName("the detail page renders the custom resource definition's kind")
     void detailRendersKind() {
-      driver.navigate().to(url.toString() + "customresourcedefinitions/" + customResourceDefinitionUid());
+      ui.openDetail("customresourcedefinitions", customResourceDefinitionUid());
 
       // Case-sensitive match: 'Widget' can only come from the CRD's spec.names.kind
       // (the CRD name only contains the lowercase plural form).
-      wait.until(d -> d.getPageSource().contains("Widget"));
-      assertThat(driver.getPageSource())
+      ui.await(() -> ui.pageContains("Widget"));
+      assertThat(ui.pageContains("Widget"))
         .as("custom resource definition detail page contents")
-        .contains("Widget");
+        .isTrue();
     }
 
     @Test
     @DisplayName("the detail page lists the seeded custom resource instance")
     void detailListsCustomResourceInstance() {
-      driver.navigate().to(url.toString() + "customresourcedefinitions/" + customResourceDefinitionUid());
+      ui.openDetail("customresourcedefinitions", customResourceDefinitionUid());
 
       // Custom resource instances are not watched: the embedded list is fetched on
       // demand through the backend's dynamic-client REST endpoint, so this row
       // proves that path end-to-end.
-      wait.until(d -> listHasRow(CUSTOM_RESOURCE_NAME));
-      assertThat(listHasRow(CUSTOM_RESOURCE_NAME))
+      ui.await(() -> ui.hasRow(CUSTOM_RESOURCE_NAME));
+      assertThat(ui.hasRow(CUSTOM_RESOURCE_NAME))
         .as("row for the seeded custom resource instance present in the detail page")
         .isTrue();
     }

--- a/src/test/java/com/marcnuri/yakd/OpenShiftIT.java
+++ b/src/test/java/com/marcnuri/yakd/OpenShiftIT.java
@@ -16,97 +16,43 @@
  */
 package com.marcnuri.yakd;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.OpenShiftDiscovery;
 import com.marcnuri.yakd.selenium.OpenShiftIntegrationTestProfile;
-import io.fabric8.kubernetes.api.model.APIGroupBuilder;
-import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
-import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(OpenShiftIntegrationTestProfile.class)
 @DisplayName("OpenShift mode")
-public class OpenShiftIT {
+public class OpenShiftIT extends AbstractResourceIT<Route> {
 
-  private static final String NAMESPACE = "default";
-  private static final String ROUTE_NAME = "openshift-it-route";
   private static final String ROUTE_HOST = "openshift-it.example.com";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
+  public OpenShiftIT() {
+    super("routes");
+  }
 
   @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    // The frontend flips to OpenShift mode when the backend reports an
-    // *.openshift.io API group (served from the cluster's /apis discovery).
-    kubernetes.expect().get().withPath("/apis").andReturn(200, new APIGroupListBuilder()
-        .addToGroups(new APIGroupBuilder().withName("route.openshift.io").build())
-        .addToGroups(new APIGroupBuilder().withName("apps.openshift.io").build())
-        .build())
-      .always();
-    // The backend only subscribes its Route/DeploymentConfig watchers when the
-    // cluster's version discovery reports the resource as supported.
-    kubernetes.expect().get().withPath("/apis/route.openshift.io/v1").andReturn(200, new APIResourceListBuilder()
-        .withGroupVersion("route.openshift.io/v1")
-        .addNewResource().withName("routes").withKind("Route").withNamespaced(true).endResource()
-        .build())
-      .always();
-    kubernetes.expect().get().withPath("/apis/apps.openshift.io/v1").andReturn(200, new APIResourceListBuilder()
-        .withGroupVersion("apps.openshift.io/v1")
-        .addNewResource().withName("deploymentconfigs").withKind("DeploymentConfig").withNamespaced(true).endResource()
-        .build())
-      .always();
-    kubernetes.getClient().resources(Route.class).inNamespace(NAMESPACE)
-      .resource(route()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  void advertiseOpenShiftDiscovery() {
+    OpenShiftDiscovery.advertise(kubernetes);
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().resources(Route.class).inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Route route() {
+  @Override
+  protected Route resource(String name) {
     return new RouteBuilder()
       .withNewMetadata()
-        .withName(ROUTE_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
       .endMetadata()
       .withNewSpec()
         .withHost(ROUTE_HOST)
@@ -116,18 +62,13 @@ public class OpenShiftIT {
       .build();
   }
 
-  private boolean listHasRow(String text) {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(text));
-  }
-
   @Nested
   @DisplayName("when rendering the side bar navigation")
   class SideBarNav {
 
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString());
+      open("");
     }
 
     @Test
@@ -135,7 +76,7 @@ public class OpenShiftIT {
     void exposesRoutesNavItem() {
       // Conditional rendering is the behavior under test: the item only exists in
       // the DOM at all when the frontend has detected OpenShift mode.
-      wait.until(d -> !d.findElements(By.cssSelector("[data-testid='side-bar__nav-routes']")).isEmpty());
+      await(() -> !driver.findElements(By.cssSelector("[data-testid='side-bar__nav-routes']")).isEmpty());
       assertThat(driver.findElements(By.cssSelector("[data-testid='side-bar__nav-routes']")))
         .as("Routes side bar navigation item")
         .isNotEmpty();
@@ -144,7 +85,7 @@ public class OpenShiftIT {
     @Test
     @DisplayName("the side bar exposes the Deployment Configs navigation item")
     void exposesDeploymentConfigsNavItem() {
-      wait.until(d -> !d.findElements(By.cssSelector("[data-testid='side-bar__nav-deploymentconfigs']")).isEmpty());
+      await(() -> !driver.findElements(By.cssSelector("[data-testid='side-bar__nav-deploymentconfigs']")).isEmpty());
       assertThat(driver.findElements(By.cssSelector("[data-testid='side-bar__nav-deploymentconfigs']")))
         .as("Deployment Configs side bar navigation item")
         .isNotEmpty();
@@ -155,13 +96,20 @@ public class OpenShiftIT {
   @DisplayName("when viewing the Route list and detail pages")
   class RouteListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedRoute() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded route")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "routes");
+      openList();
 
-      wait.until(d -> listHasRow(ROUTE_NAME));
-      assertThat(listHasRow(ROUTE_NAME))
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded route present in the list")
         .isTrue();
     }
@@ -169,10 +117,10 @@ public class OpenShiftIT {
     @Test
     @DisplayName("the list row shows the route's host")
     void listRowShowsHost() {
-      driver.navigate().to(url.toString() + "routes");
+      openList();
 
-      wait.until(d -> listHasRow(ROUTE_HOST));
-      assertThat(listHasRow(ROUTE_HOST))
+      await(() -> rowShows(name, ROUTE_HOST));
+      assertThat(rowShows(name, ROUTE_HOST))
         .as("seeded host shown in the route's row")
         .isTrue();
     }
@@ -180,16 +128,12 @@ public class OpenShiftIT {
     @Test
     @DisplayName("the detail page renders the route's host")
     void detailRendersHost() {
-      final Route seeded = kubernetes.getClient().resources(Route.class)
-        .inNamespace(NAMESPACE).withName(ROUTE_NAME).get();
-      assertThat(seeded).as("seeded route available before navigating").isNotNull();
+      openDetail(seededUid(name));
 
-      driver.navigate().to(url.toString() + "routes/" + seeded.getMetadata().getUid());
-
-      wait.until(d -> d.getPageSource().contains(ROUTE_HOST));
-      assertThat(driver.getPageSource())
+      awaitPageContains(ROUTE_HOST);
+      assertThat(pageContains(ROUTE_HOST))
         .as("route detail page contents")
-        .contains(ROUTE_HOST);
+        .isTrue();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/clusterrolebindings/ClusterRoleBindingIT.java
+++ b/src/test/java/com/marcnuri/yakd/clusterrolebindings/ClusterRoleBindingIT.java
@@ -16,86 +16,43 @@
  */
 package com.marcnuri.yakd.clusterrolebindings;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.RbacDiscovery;
 import com.marcnuri.yakd.selenium.RbacIntegrationTestProfile;
-import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(RbacIntegrationTestProfile.class)
 @DisplayName("ClusterRoleBinding")
-public class ClusterRoleBindingIT {
+public class ClusterRoleBindingIT extends AbstractResourceIT<ClusterRoleBinding> {
 
-  private static final String CLUSTER_ROLE_BINDING_NAME = "it-cluster-role-binding";
   private static final String DETAIL_MARKER = "cluster-role-binding-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
+  public ClusterRoleBindingIT() {
+    super("clusterrolebindings");
+  }
 
   @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
+  void advertiseRbacDiscovery() {
     // The ClusterRoleBinding watcher only subscribes when the cluster's discovery reports
     // clusterrolebindings as supported; the CRUD mock does not advertise them by default.
-    kubernetes.expect().get().withPath("/apis/rbac.authorization.k8s.io/v1")
-      .andReturn(200, new APIResourceListBuilder()
-        .withGroupVersion("rbac.authorization.k8s.io/v1")
-        .addNewResource().withName("clusterroles").withKind("ClusterRole").withNamespaced(false).endResource()
-        .addNewResource().withName("clusterrolebindings").withKind("ClusterRoleBinding").withNamespaced(false).endResource()
-        .addNewResource().withName("roles").withKind("Role").withNamespaced(true).endResource()
-        .addNewResource().withName("rolebindings").withKind("RoleBinding").withNamespaced(true).endResource()
-        .build())
-      .always();
-    kubernetes.getClient().rbac().clusterRoleBindings()
-      .resource(clusterRoleBinding()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+    RbacDiscovery.advertise(kubernetes);
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().rbac().clusterRoleBindings().withName(CLUSTER_ROLE_BINDING_NAME).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static ClusterRoleBinding clusterRoleBinding() {
+  @Override
+  protected ClusterRoleBinding resource(String name) {
     return new ClusterRoleBindingBuilder()
       .withNewMetadata()
-        .withName(CLUSTER_ROLE_BINDING_NAME)
+        .withName(name)
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -108,38 +65,24 @@ public class ClusterRoleBindingIT {
       .build();
   }
 
-  private boolean listHasClusterRoleBindingRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(CLUSTER_ROLE_BINDING_NAME));
-  }
-
-  private String seededUid() {
-    final ClusterRoleBinding seeded = kubernetes.getClient().rbac().clusterRoleBindings()
-      .withName(CLUSTER_ROLE_BINDING_NAME).get();
-    assertThat(seeded).as("seeded cluster role binding available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final ClusterRoleBinding clusterRoleBinding = kubernetes.getClient().rbac().clusterRoleBindings()
-      .withName(CLUSTER_ROLE_BINDING_NAME).get();
-    if (clusterRoleBinding == null || clusterRoleBinding.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return clusterRoleBinding.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded cluster role binding")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "clusterrolebindings");
+      openList();
 
-      wait.until(d -> listHasClusterRoleBindingRow());
-      assertThat(listHasClusterRoleBindingRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded cluster role binding present in the list")
         .isTrue();
     }
@@ -147,14 +90,14 @@ public class ClusterRoleBindingIT {
     @Test
     @DisplayName("the detail page renders the cluster role binding's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "clusterrolebindings/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("cluster role binding detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -162,22 +105,22 @@ public class ClusterRoleBindingIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "clusterrolebindings");
-      wait.until(d -> listHasClusterRoleBindingRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the cluster role binding's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(CLUSTER_ROLE_BINDING_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasClusterRoleBindingRow());
-      assertThat(listHasClusterRoleBindingRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("cluster role binding row still present after delete")
         .isFalse();
     }
@@ -187,32 +130,25 @@ public class ClusterRoleBindingIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "clusterrolebindings/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted cluster role binding")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/clusterroles/ClusterRoleIT.java
+++ b/src/test/java/com/marcnuri/yakd/clusterroles/ClusterRoleIT.java
@@ -16,86 +16,43 @@
  */
 package com.marcnuri.yakd.clusterroles;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.RbacDiscovery;
 import com.marcnuri.yakd.selenium.RbacIntegrationTestProfile;
-import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(RbacIntegrationTestProfile.class)
 @DisplayName("ClusterRole")
-public class ClusterRoleIT {
+public class ClusterRoleIT extends AbstractResourceIT<ClusterRole> {
 
-  private static final String CLUSTER_ROLE_NAME = "it-cluster-role";
   private static final String DETAIL_MARKER = "cluster-role-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
+  public ClusterRoleIT() {
+    super("clusterroles");
+  }
 
   @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    // The ClusterRole watcher only subscribes when the cluster's discovery reports
-    // clusterroles as supported; the CRUD mock does not advertise them by default.
-    kubernetes.expect().get().withPath("/apis/rbac.authorization.k8s.io/v1")
-      .andReturn(200, new APIResourceListBuilder()
-        .withGroupVersion("rbac.authorization.k8s.io/v1")
-        .addNewResource().withName("clusterroles").withKind("ClusterRole").withNamespaced(false).endResource()
-        .addNewResource().withName("clusterrolebindings").withKind("ClusterRoleBinding").withNamespaced(false).endResource()
-        .addNewResource().withName("roles").withKind("Role").withNamespaced(true).endResource()
-        .addNewResource().withName("rolebindings").withKind("RoleBinding").withNamespaced(true).endResource()
-        .build())
-      .always();
-    kubernetes.getClient().rbac().clusterRoles()
-      .resource(clusterRole()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  void advertiseRbacDiscovery() {
+    // The ClusterRole watcher only subscribes when the cluster's discovery reports clusterroles
+    // as supported; the CRUD mock does not advertise them by default.
+    RbacDiscovery.advertise(kubernetes);
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().rbac().clusterRoles().withName(CLUSTER_ROLE_NAME).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static ClusterRole clusterRole() {
+  @Override
+  protected ClusterRole resource(String name) {
     return new ClusterRoleBuilder()
       .withNewMetadata()
-        .withName(CLUSTER_ROLE_NAME)
+        .withName(name)
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -105,38 +62,24 @@ public class ClusterRoleIT {
       .build();
   }
 
-  private boolean listHasClusterRoleRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(CLUSTER_ROLE_NAME));
-  }
-
-  private String seededUid() {
-    final ClusterRole seeded = kubernetes.getClient().rbac().clusterRoles()
-      .withName(CLUSTER_ROLE_NAME).get();
-    assertThat(seeded).as("seeded cluster role available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final ClusterRole clusterRole = kubernetes.getClient().rbac().clusterRoles()
-      .withName(CLUSTER_ROLE_NAME).get();
-    if (clusterRole == null || clusterRole.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return clusterRole.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded cluster role")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "clusterroles");
+      openList();
 
-      wait.until(d -> listHasClusterRoleRow());
-      assertThat(listHasClusterRoleRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded cluster role present in the list")
         .isTrue();
     }
@@ -144,14 +87,14 @@ public class ClusterRoleIT {
     @Test
     @DisplayName("the detail page renders the cluster role's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "clusterroles/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("cluster role detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -159,22 +102,22 @@ public class ClusterRoleIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "clusterroles");
-      wait.until(d -> listHasClusterRoleRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the cluster role's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(CLUSTER_ROLE_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasClusterRoleRow());
-      assertThat(listHasClusterRoleRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("cluster role row still present after delete")
         .isFalse();
     }
@@ -184,32 +127,25 @@ public class ClusterRoleIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "clusterroles/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted cluster role")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/configmaps/ConfigMapIT.java
+++ b/src/test/java/com/marcnuri/yakd/configmaps/ConfigMapIT.java
@@ -16,114 +16,60 @@
  */
 package com.marcnuri.yakd.configmaps;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("ConfigMap")
-public class ConfigMapIT {
+public class ConfigMapIT extends AbstractResourceIT<ConfigMap> {
 
-  private static final String NAMESPACE = "default";
-  private static final String CONFIG_MAP_NAME = "it-config-map";
   private static final String DETAIL_MARKER = "config-map-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().configMaps().inNamespace(NAMESPACE)
-      .resource(configMap()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public ConfigMapIT() {
+    super("configmaps");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().configMaps().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static ConfigMap configMap() {
+  @Override
+  protected ConfigMap resource(String name) {
     return new ConfigMapBuilder()
       .withNewMetadata()
-        .withName(CONFIG_MAP_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
       .endMetadata()
       .addToData("detail-key", DETAIL_MARKER)
       .build();
   }
 
-  private boolean listHasConfigMapRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(CONFIG_MAP_NAME));
-  }
-
-  private String seededUid() {
-    final ConfigMap seeded = kubernetes.getClient().configMaps()
-      .inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).get();
-    assertThat(seeded).as("seeded config map available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final ConfigMap configMap = kubernetes.getClient().configMaps()
-      .inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).get();
-    if (configMap == null || configMap.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return configMap.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded config map")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "configmaps");
+      openList();
 
-      wait.until(d -> listHasConfigMapRow());
-      assertThat(listHasConfigMapRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded config map present in the list")
         .isTrue();
     }
@@ -131,14 +77,14 @@ public class ConfigMapIT {
     @Test
     @DisplayName("the detail page renders the config map's data value")
     void detailRendersDataValue() {
-      driver.navigate().to(url.toString() + "configmaps/" + seededUid());
+      openDetail(seededUid(name));
 
       // The data value can only come from the seeded resource's data map, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("config map detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -146,22 +92,22 @@ public class ConfigMapIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "configmaps");
-      wait.until(d -> listHasConfigMapRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the config map's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(CONFIG_MAP_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasConfigMapRow());
-      assertThat(listHasConfigMapRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("config map row still present after delete")
         .isFalse();
     }
@@ -171,32 +117,25 @@ public class ConfigMapIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "configmaps/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted config map")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/cronjobs/CronJobMutationIT.java
+++ b/src/test/java/com/marcnuri/yakd/cronjobs/CronJobMutationIT.java
@@ -16,78 +16,41 @@
  */
 package com.marcnuri.yakd.cronjobs;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.batch.v1.CronJob;
 import io.fabric8.kubernetes.api.model.batch.v1.CronJobBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("CronJob mutation paths")
-public class CronJobMutationIT {
+public class CronJobMutationIT extends AbstractResourceIT<CronJob> {
 
-  private static final String NAMESPACE = "default";
-  private static final String CRONJOB_NAME = "mutation-it-cronjob";
   private static final By TOGGLE = By.cssSelector("[data-testid='cronjob-detail__suspend-toggle']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().batch().v1().cronjobs().inNamespace(NAMESPACE)
-      .resource(cronJob(false)).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public CronJobMutationIT() {
+    super("cronjobs");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().batch().v1().cronjobs().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static CronJob cronJob(boolean suspend) {
+  @Override
+  protected CronJob resource(String name) {
     return new CronJobBuilder()
       .withNewMetadata()
-        .withName(CRONJOB_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
       .endMetadata()
       .withNewSpec()
         .withSchedule("*/1 * * * *")
-        .withSuspend(suspend)
+        .withSuspend(false)
         .withNewJobTemplate()
           .withNewSpec()
             .withNewTemplate()
@@ -102,16 +65,12 @@ public class CronJobMutationIT {
       .build();
   }
 
-  // Navigate to the detail page of the seeded CronJob and wait until the watch has
-  // loaded it into the store. The toggle renders fa-pause-circle for an undefined
-  // resource too (specSuspend(undefined) === false), so the name only renders once
-  // the resource is loaded and is the safe gate before trusting the toggle state.
-  private void navigateToDetail() {
-    final CronJob seeded = kubernetes.getClient().batch().v1().cronjobs()
-      .inNamespace(NAMESPACE).withName(CRONJOB_NAME).get();
-    assertThat(seeded).as("seeded cronjob available before navigating").isNotNull();
-    driver.navigate().to(url.toString() + "cronjobs/" + seeded.getMetadata().getUid());
-    wait.until(d -> d.getPageSource().contains(CRONJOB_NAME));
+  // The toggle renders fa-pause-circle for an undefined resource too (specSuspend(undefined) ===
+  // false), so the name only renders once the resource is loaded and is the safe gate before
+  // trusting the toggle state.
+  private void navigateToDetail(String name) {
+    openDetail(seededUid(name));
+    awaitPageContains(name);
   }
 
   // The toggle renders fa-pause-circle while running and fa-play-circle while suspended,
@@ -121,9 +80,9 @@ public class CronJobMutationIT {
       .anyMatch(e -> e.getAttribute("class").contains(iconClass));
   }
 
-  private Boolean backendSuspended() {
+  private Boolean backendSuspended(String name) {
     final CronJob cronJob = kubernetes.getClient().batch().v1().cronjobs()
-      .inNamespace(NAMESPACE).withName(CRONJOB_NAME).get();
+      .inNamespace("default").withName(name).get();
     if (cronJob == null || cronJob.getSpec() == null) {
       return null;
     }
@@ -134,10 +93,13 @@ public class CronJobMutationIT {
   @DisplayName("when suspending a running cronjob")
   class Suspend {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      navigateToDetail();
-      wait.until(d -> toggleShows("fa-pause-circle"));
+      name = seed("to-suspend");
+      navigateToDetail(name);
+      await(() -> toggleShows("fa-pause-circle"));
     }
 
     @Test
@@ -145,8 +107,8 @@ public class CronJobMutationIT {
     void toggleSuspends() {
       driver.findElement(TOGGLE).click();
 
-      wait.until(d -> Boolean.TRUE.equals(backendSuspended()));
-      assertThat(backendSuspended())
+      await(() -> Boolean.TRUE.equals(backendSuspended(name)));
+      assertThat(backendSuspended(name))
         .as("spec.suspend on the persisted cronjob")
         .isTrue();
     }
@@ -156,12 +118,15 @@ public class CronJobMutationIT {
   @DisplayName("when resuming a suspended cronjob")
   class Resume {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      kubernetes.getClient().batch().v1().cronjobs().inNamespace(NAMESPACE).withName(CRONJOB_NAME)
+      name = seed("to-resume");
+      kubernetes.getClient().batch().v1().cronjobs().inNamespace("default").withName(name)
         .edit(cronJob -> new CronJobBuilder(cronJob).editSpec().withSuspend(true).endSpec().build());
-      navigateToDetail();
-      wait.until(d -> toggleShows("fa-play-circle"));
+      navigateToDetail(name);
+      await(() -> toggleShows("fa-play-circle"));
     }
 
     @Test
@@ -169,8 +134,8 @@ public class CronJobMutationIT {
     void toggleResumes() {
       driver.findElement(TOGGLE).click();
 
-      wait.until(d -> Boolean.FALSE.equals(backendSuspended()));
-      assertThat(backendSuspended())
+      await(() -> Boolean.FALSE.equals(backendSuspended(name)));
+      assertThat(backendSuspended(name))
         .as("spec.suspend on the persisted cronjob")
         .isFalse();
     }

--- a/src/test/java/com/marcnuri/yakd/deployment/DeploymentIT.java
+++ b/src/test/java/com/marcnuri/yakd/deployment/DeploymentIT.java
@@ -16,80 +16,38 @@
  */
 package com.marcnuri.yakd.deployment;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Deployment")
-public class DeploymentIT {
+public class DeploymentIT extends AbstractResourceIT<Deployment> {
 
-  private static final String NAMESPACE = "default";
-  private static final String DEPLOYMENT_NAME = "mutation-it-deployment";
-  private static final String ADDED_DEPLOYMENT_NAME = "watch-added-deployment";
   private static final String SEEDED_IMAGE = "busybox";
   private static final String MODIFIED_IMAGE = "nginx:1.25";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().apps().deployments().inNamespace(NAMESPACE)
-      .resource(deployment()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public DeploymentIT() {
+    super("deployments");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().apps().deployments().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Deployment deployment() {
-    return deployment(DEPLOYMENT_NAME);
-  }
-
-  private static Deployment deployment(String name) {
-    return deployment(name, NAMESPACE);
+  @Override
+  protected Deployment resource(String name) {
+    return deployment(name, "default");
   }
 
   private static Deployment deployment(String name, String namespace) {
@@ -112,42 +70,18 @@ public class DeploymentIT {
       .build();
   }
 
-  private boolean listHasRow(String deploymentName) {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(deploymentName));
-  }
-
-  private boolean listHasDeploymentRow() {
-    return listHasRow(DEPLOYMENT_NAME);
-  }
-
-  private boolean deploymentRowShowsImage(String image) {
-    return driver.findElements(ROW).stream()
-      .filter(row -> row.getText().contains(DEPLOYMENT_NAME))
-      .anyMatch(row -> row.getText().contains(image));
-  }
-
-  private String backendMarker() {
+  private Integer backendReplicas(String name) {
     final Deployment deployment = kubernetes.getClient().apps().deployments()
-      .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
-    if (deployment == null || deployment.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return deployment.getMetadata().getLabels().get("mutation-marker");
-  }
-
-  private Integer backendReplicas() {
-    final Deployment deployment = kubernetes.getClient().apps().deployments()
-      .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
+      .inNamespace("default").withName(name).get();
     if (deployment == null || deployment.getSpec() == null) {
       return null;
     }
     return deployment.getSpec().getReplicas();
   }
 
-  private String backendRestartedAt() {
+  private String backendRestartedAt(String name) {
     final Deployment deployment = kubernetes.getClient().apps().deployments()
-      .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
+      .inNamespace("default").withName(name).get();
     if (deployment == null || deployment.getSpec() == null
       || deployment.getSpec().getTemplate() == null
       || deployment.getSpec().getTemplate().getMetadata() == null
@@ -159,22 +93,83 @@ public class DeploymentIT {
   }
 
   @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
+    @Test
+    @DisplayName("the list renders a row for the seeded deployment")
+    void listRendersSeededRow() {
+      openList();
+
+      awaitRow(name);
+      assertThat(hasRow(name))
+        .as("row for the seeded deployment present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the list row shows the seeded deployment's container image")
+    void listRowShowsImage() {
+      openList();
+
+      await(() -> rowShows(name, SEEDED_IMAGE));
+      assertThat(rowShows(name, SEEDED_IMAGE))
+        .as("seeded container image shown in the deployment's row")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the side bar does not expose the OpenShift navigation items")
+    void sideBarHasNoOpenShiftNav() {
+      openList();
+
+      // Gate on the page being fully loaded (watch synced) so the absence below
+      // cannot pass vacuously against a not-yet-rendered side bar.
+      awaitRow(name);
+      assertThat(driver.findElements(By.cssSelector("[data-testid='side-bar__nav-routes']")))
+        .as("Routes side bar navigation item in vanilla Kubernetes mode")
+        .isEmpty();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the deployment's name")
+    void detailRendersName() {
+      openDetail(seededUid(name));
+
+      awaitPageContains(name);
+      assertThat(pageContains(name))
+        .as("detail page contents")
+        .isTrue();
+    }
+  }
+
+  @Nested
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "deployments");
-      wait.until(d -> listHasDeploymentRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the deployment's row from the list")
     void deleteRemovesRow() {
-      driver.findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasDeploymentRow());
-      assertThat(listHasDeploymentRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("deployment row still present after delete")
         .isFalse();
     }
@@ -184,37 +179,25 @@ public class DeploymentIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      // The MockServer assigns its own uid on create, so resolve the stored uid
-      // rather than relying on a client-provided one; the edit page keys off it.
-      final Deployment seeded = kubernetes.getClient().apps().deployments()
-        .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
-      assertThat(seeded).as("seeded deployment available before editing").isNotNull();
-      driver.navigate().to(url.toString() + "deployments/" + seeded.getMetadata().getUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted deployment")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 
@@ -222,15 +205,15 @@ public class DeploymentIT {
   @DisplayName("when scaling from the detail page")
   class Scale {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      final Deployment seeded = kubernetes.getClient().apps().deployments()
-        .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
-      assertThat(seeded).as("seeded deployment available before scaling").isNotNull();
-      driver.navigate().to(url.toString() + "deployments/" + seeded.getMetadata().getUid());
+      name = seed("to-scale");
+      openDetail(seededUid(name));
       // The replicas control operates on the resource once the watch has loaded it
       // into the store; the name only renders after that, so it is a safe gate.
-      wait.until(d -> d.getPageSource().contains(DEPLOYMENT_NAME));
+      awaitPageContains(name);
     }
 
     @Test
@@ -238,8 +221,8 @@ public class DeploymentIT {
     void incrementPersistsReplicas() {
       driver.findElement(By.cssSelector("[data-testid='replicas-field__increment']")).click();
 
-      wait.until(d -> Integer.valueOf(2).equals(backendReplicas()));
-      assertThat(backendReplicas())
+      await(() -> Integer.valueOf(2).equals(backendReplicas(name)));
+      assertThat(backendReplicas(name))
         .as("spec.replicas on the persisted deployment")
         .isEqualTo(2);
     }
@@ -249,10 +232,13 @@ public class DeploymentIT {
   @DisplayName("when restarting from the list page")
   class Restart {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "deployments");
-      wait.until(d -> listHasDeploymentRow());
+      name = seed("to-restart");
+      openList();
+      awaitRow(name);
     }
 
     @Test
@@ -260,8 +246,8 @@ public class DeploymentIT {
     void restartRecordsRestartedAt() {
       driver.findElement(By.cssSelector("[data-testid='deployment-list__restart']")).click();
 
-      wait.until(d -> backendRestartedAt() != null);
-      assertThat(backendRestartedAt())
+      await(() -> backendRestartedAt(name) != null);
+      assertThat(backendRestartedAt(name))
         .as("kubectl.kubernetes.io/restartedAt annotation on the persisted deployment")
         .isNotNull();
     }
@@ -271,23 +257,25 @@ public class DeploymentIT {
   @DisplayName("when the server pushes live watch events")
   class WatchLiveUpdates {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "deployments");
-      // Waiting for the seeded row guarantees the watch SSE stream is connected and
-      // its initial sync has been replayed before the test mutates the cluster, so any
-      // later change can only reach the list through a live watch event.
-      wait.until(d -> listHasDeploymentRow());
+      name = seed("to-watch");
+      openList();
+      // Waiting for the seeded row guarantees the watch SSE stream is connected and its initial
+      // sync has been replayed before the test mutates the cluster, so any later change can only
+      // reach the list through a live watch event.
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("a deployment created server-side appears in the list without a refresh")
     void createdDeploymentAppears() {
-      kubernetes.getClient().apps().deployments().inNamespace(NAMESPACE)
-        .resource(deployment(ADDED_DEPLOYMENT_NAME)).create();
+      final String added = seed("watch-added");
 
-      wait.until(d -> listHasRow(ADDED_DEPLOYMENT_NAME));
-      assertThat(listHasRow(ADDED_DEPLOYMENT_NAME))
+      awaitRow(added);
+      assertThat(hasRow(added))
         .as("row for the server-side-created deployment present in the list")
         .isTrue();
     }
@@ -295,11 +283,10 @@ public class DeploymentIT {
     @Test
     @DisplayName("a deployment deleted server-side disappears from the list without a refresh")
     void deletedDeploymentDisappears() {
-      kubernetes.getClient().apps().deployments().inNamespace(NAMESPACE)
-        .withName(DEPLOYMENT_NAME).delete();
+      kubernetes.getClient().apps().deployments().inNamespace("default").withName(name).delete();
 
-      wait.until(d -> !listHasDeploymentRow());
-      assertThat(listHasDeploymentRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("row for the server-side-deleted deployment still present in the list")
         .isFalse();
     }
@@ -307,74 +294,17 @@ public class DeploymentIT {
     @Test
     @DisplayName("a deployment modified server-side updates its row in place without a refresh")
     void modifiedDeploymentUpdatesRow() {
-      kubernetes.getClient().apps().deployments().inNamespace(NAMESPACE)
-        .withName(DEPLOYMENT_NAME)
+      kubernetes.getClient().apps().deployments().inNamespace("default").withName(name)
         .edit(d -> new DeploymentBuilder(d)
           .editSpec().editTemplate().editSpec()
             .editFirstContainer().withImage(MODIFIED_IMAGE).endContainer()
           .endSpec().endTemplate().endSpec()
           .build());
 
-      wait.until(d -> deploymentRowShowsImage(MODIFIED_IMAGE));
-      assertThat(deploymentRowShowsImage(MODIFIED_IMAGE))
+      await(() -> rowShows(name, MODIFIED_IMAGE));
+      assertThat(rowShows(name, MODIFIED_IMAGE))
         .as("deployment row reflects the server-side image change")
         .isTrue();
-    }
-  }
-
-  @Nested
-  @DisplayName("when viewing the list and detail pages")
-  class ListAndDetail {
-
-    @Test
-    @DisplayName("the list renders a row for the seeded deployment")
-    void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "deployments");
-
-      wait.until(d -> listHasDeploymentRow());
-      assertThat(listHasDeploymentRow())
-        .as("row for the seeded deployment present in the list")
-        .isTrue();
-    }
-
-    @Test
-    @DisplayName("the list row shows the seeded deployment's container image")
-    void listRowShowsImage() {
-      driver.navigate().to(url.toString() + "deployments");
-
-      wait.until(d -> deploymentRowShowsImage(SEEDED_IMAGE));
-      assertThat(deploymentRowShowsImage(SEEDED_IMAGE))
-        .as("seeded container image shown in the deployment's row")
-        .isTrue();
-    }
-
-    @Test
-    @DisplayName("the side bar does not expose the OpenShift navigation items")
-    void sideBarHasNoOpenShiftNav() {
-      driver.navigate().to(url.toString() + "deployments");
-
-      // Gate on the page being fully loaded (watch synced) so the absence below
-      // cannot pass vacuously against a not-yet-rendered side bar; also guards
-      // that OpenShiftIT's /apis expectations stay on its own dedicated profile.
-      wait.until(d -> listHasDeploymentRow());
-      assertThat(driver.findElements(By.cssSelector("[data-testid='side-bar__nav-routes']")))
-        .as("Routes side bar navigation item in vanilla Kubernetes mode")
-        .isEmpty();
-    }
-
-    @Test
-    @DisplayName("the detail page renders the deployment's name")
-    void detailRendersName() {
-      final Deployment seeded = kubernetes.getClient().apps().deployments()
-        .inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get();
-      assertThat(seeded).as("seeded deployment available before navigating").isNotNull();
-
-      driver.navigate().to(url.toString() + "deployments/" + seeded.getMetadata().getUid());
-
-      wait.until(d -> d.getPageSource().contains(DEPLOYMENT_NAME));
-      assertThat(driver.getPageSource())
-        .as("detail page contents")
-        .contains(DEPLOYMENT_NAME);
     }
   }
 
@@ -386,42 +316,45 @@ public class DeploymentIT {
     private static final String OTHER_DEPLOYMENT_NAME = "filter-other-deployment";
     private static final By NAMESPACE_ITEM = By.cssSelector("[data-testid='filter-bar__namespace-item']");
 
+    private String name;
+
     @BeforeEach
     void seedOtherNamespaceAndFilter() {
+      name = seed("filter-selected");
       // The FilterBar lists Namespace resources streamed through the watch, so both
       // namespaces must exist as actual resources for their dropdown items to render.
       kubernetes.getClient().namespaces().resource(new NamespaceBuilder()
-        .withNewMetadata().withName(NAMESPACE).endMetadata().build()).createOr(NonDeletingOperation::update);
+        .withNewMetadata().withName("default").endMetadata().build()).createOr(NonDeletingOperation::update);
       kubernetes.getClient().namespaces().resource(new NamespaceBuilder()
         .withNewMetadata().withName(OTHER_NAMESPACE).endMetadata().build()).createOr(NonDeletingOperation::update);
-      kubernetes.getClient().apps().deployments().inNamespace(OTHER_NAMESPACE)
-        .resource(deployment(OTHER_DEPLOYMENT_NAME, OTHER_NAMESPACE)).createOr(NonDeletingOperation::update);
-      driver.navigate().to(url.toString() + "deployments");
-      wait.until(d -> listHasDeploymentRow() && listHasRow(OTHER_DEPLOYMENT_NAME));
+      kubernetes.getClient().resource(deployment(OTHER_DEPLOYMENT_NAME, OTHER_NAMESPACE))
+        .createOr(NonDeletingOperation::update);
+      openList();
+      await(() -> hasRow(name) && hasRow(OTHER_DEPLOYMENT_NAME));
       driver.findElement(By.cssSelector("[data-testid='filter-bar__namespace'] button")).click();
       // Item texts are only visible once the panel is open, so matching by text also
       // waits for the dropdown to be effectively expanded.
-      wait.until(d -> d.findElements(NAMESPACE_ITEM).stream()
-        .anyMatch(item -> item.getText().equals(NAMESPACE)));
+      await(() -> driver.findElements(NAMESPACE_ITEM).stream()
+        .anyMatch(item -> item.getText().equals("default")));
       driver.findElements(NAMESPACE_ITEM).stream()
-        .filter(item -> item.getText().equals(NAMESPACE))
+        .filter(item -> item.getText().equals("default"))
         .findFirst().orElseThrow().click();
     }
 
     @AfterEach
     void deleteOtherNamespaceResources() {
-      kubernetes.getClient().apps().deployments().inNamespace(OTHER_NAMESPACE).delete();
+      kubernetes.getClient().resource(deployment(OTHER_DEPLOYMENT_NAME, OTHER_NAMESPACE)).delete();
       // Delete the seeded Namespace resources too: the mock server outlives this
       // class, so a leaked namespace would show up in every later FilterBar.
       kubernetes.getClient().namespaces().withName(OTHER_NAMESPACE).delete();
-      kubernetes.getClient().namespaces().withName(NAMESPACE).delete();
+      kubernetes.getClient().namespaces().withName("default").delete();
     }
 
     @Test
     @DisplayName("selecting a namespace hides deployments from other namespaces")
     void hidesOtherNamespaceRows() {
-      wait.until(d -> !listHasRow(OTHER_DEPLOYMENT_NAME));
-      assertThat(listHasRow(OTHER_DEPLOYMENT_NAME))
+      awaitNoRow(OTHER_DEPLOYMENT_NAME);
+      assertThat(hasRow(OTHER_DEPLOYMENT_NAME))
         .as("row for the other-namespace deployment still present after filtering")
         .isFalse();
     }
@@ -429,8 +362,8 @@ public class DeploymentIT {
     @Test
     @DisplayName("selecting a namespace keeps deployments in that namespace visible")
     void keepsSelectedNamespaceRows() {
-      wait.until(d -> !listHasRow(OTHER_DEPLOYMENT_NAME));
-      assertThat(listHasDeploymentRow())
+      awaitNoRow(OTHER_DEPLOYMENT_NAME);
+      assertThat(hasRow(name))
         .as("row for the selected-namespace deployment present after filtering")
         .isTrue();
     }
@@ -442,19 +375,22 @@ public class DeploymentIT {
 
     private static final By SEARCH_INPUT = By.cssSelector("[data-testid='search__input']");
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "search");
-      wait.until(d -> d.findElement(SEARCH_INPUT).isDisplayed());
+      name = seed("to-search");
+      open("search");
+      await(() -> driver.findElement(SEARCH_INPUT).isDisplayed());
     }
 
     @Test
     @DisplayName("a query matching the seeded deployment shows its row in the results")
     void matchingQueryShowsRow() {
-      driver.findElement(SEARCH_INPUT).sendKeys(DEPLOYMENT_NAME);
+      driver.findElement(SEARCH_INPUT).sendKeys(name);
 
-      wait.until(d -> listHasDeploymentRow());
-      assertThat(listHasDeploymentRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded deployment present in the search results")
         .isTrue();
     }
@@ -462,15 +398,15 @@ public class DeploymentIT {
     @Test
     @DisplayName("narrowing the query to a non-matching term hides the results")
     void nonMatchingQueryHidesRows() {
-      driver.findElement(SEARCH_INPUT).sendKeys(DEPLOYMENT_NAME);
+      driver.findElement(SEARCH_INPUT).sendKeys(name);
       // Gate on the matching row first so its later absence proves the query
       // narrowed the results rather than the store never having synced.
-      wait.until(d -> listHasDeploymentRow());
+      awaitRow(name);
 
       driver.findElement(SEARCH_INPUT).sendKeys("-no-match");
 
-      wait.until(d -> !listHasDeploymentRow());
-      assertThat(listHasDeploymentRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("deployment row still present after narrowing the query to a non-matching term")
         .isFalse();
     }

--- a/src/test/java/com/marcnuri/yakd/endpoints/EndpointIT.java
+++ b/src/test/java/com/marcnuri/yakd/endpoints/EndpointIT.java
@@ -16,75 +16,36 @@
  */
 package com.marcnuri.yakd.endpoints;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Endpoint")
-public class EndpointIT {
+public class EndpointIT extends AbstractResourceIT<Endpoints> {
 
-  private static final String NAMESPACE = "default";
-  private static final String ENDPOINT_NAME = "it-endpoint";
   private static final String ADDRESS_IP = "10.40.50.60";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().endpoints().inNamespace(NAMESPACE)
-      .resource(endpoint()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public EndpointIT() {
+    super("endpoints");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().endpoints().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Endpoints endpoint() {
+  @Override
+  protected Endpoints resource(String name) {
     return new EndpointsBuilder()
       .withNewMetadata()
-        .withName(ENDPOINT_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
       .endMetadata()
       .addNewSubset()
         .addNewAddress()
@@ -100,29 +61,24 @@ public class EndpointIT {
       .build();
   }
 
-  private boolean listHasEndpointRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(ENDPOINT_NAME));
-  }
-
-  private String seededUid() {
-    final Endpoints seeded = kubernetes.getClient().endpoints()
-      .inNamespace(NAMESPACE).withName(ENDPOINT_NAME).get();
-    assertThat(seeded).as("seeded endpoint available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded endpoint")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "endpoints");
+      openList();
 
-      wait.until(d -> listHasEndpointRow());
-      assertThat(listHasEndpointRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded endpoint present in the list")
         .isTrue();
     }
@@ -130,14 +86,14 @@ public class EndpointIT {
     @Test
     @DisplayName("the detail page renders the endpoint's subset address")
     void detailRendersAddress() {
-      driver.navigate().to(url.toString() + "endpoints/" + seededUid());
+      openDetail(seededUid(name));
 
       // The address IP can only come from the seeded resource's subsets, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(ADDRESS_IP));
-      assertThat(driver.getPageSource())
+      awaitPageContains(ADDRESS_IP);
+      assertThat(pageContains(ADDRESS_IP))
         .as("endpoint detail page contents")
-        .contains(ADDRESS_IP);
+        .isTrue();
     }
   }
 
@@ -147,22 +103,22 @@ public class EndpointIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "endpoints");
-      wait.until(d -> listHasEndpointRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the endpoint's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(ENDPOINT_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasEndpointRow());
-      assertThat(listHasEndpointRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("endpoint row still present after delete")
         .isFalse();
     }

--- a/src/test/java/com/marcnuri/yakd/horizontalpodautoscalers/HorizontalPodAutoscalerIT.java
+++ b/src/test/java/com/marcnuri/yakd/horizontalpodautoscalers/HorizontalPodAutoscalerIT.java
@@ -16,76 +16,36 @@
  */
 package com.marcnuri.yakd.horizontalpodautoscalers;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscaler;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("HorizontalPodAutoscaler")
-public class HorizontalPodAutoscalerIT {
+public class HorizontalPodAutoscalerIT extends AbstractResourceIT<HorizontalPodAutoscaler> {
 
-  private static final String NAMESPACE = "default";
-  private static final String HPA_NAME = "it-horizontal-pod-autoscaler";
   private static final String DETAIL_MARKER = "horizontal-pod-autoscaler-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().autoscaling().v1().horizontalPodAutoscalers().inNamespace(NAMESPACE)
-      .resource(horizontalPodAutoscaler()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public HorizontalPodAutoscalerIT() {
+    super("horizontalpodautoscalers");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().autoscaling().v1().horizontalPodAutoscalers().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static HorizontalPodAutoscaler horizontalPodAutoscaler() {
+  @Override
+  protected HorizontalPodAutoscaler resource(String name) {
     return new HorizontalPodAutoscalerBuilder()
       .withNewMetadata()
-        .withName(HPA_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -98,38 +58,24 @@ public class HorizontalPodAutoscalerIT {
       .build();
   }
 
-  private boolean listHasHorizontalPodAutoscalerRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(HPA_NAME));
-  }
-
-  private String seededUid() {
-    final HorizontalPodAutoscaler seeded = kubernetes.getClient().autoscaling().v1()
-      .horizontalPodAutoscalers().inNamespace(NAMESPACE).withName(HPA_NAME).get();
-    assertThat(seeded).as("seeded horizontal pod autoscaler available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final HorizontalPodAutoscaler horizontalPodAutoscaler = kubernetes.getClient().autoscaling().v1()
-      .horizontalPodAutoscalers().inNamespace(NAMESPACE).withName(HPA_NAME).get();
-    if (horizontalPodAutoscaler == null || horizontalPodAutoscaler.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return horizontalPodAutoscaler.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded horizontal pod autoscaler")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "horizontalpodautoscalers");
+      openList();
 
-      wait.until(d -> listHasHorizontalPodAutoscalerRow());
-      assertThat(listHasHorizontalPodAutoscalerRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded horizontal pod autoscaler present in the list")
         .isTrue();
     }
@@ -137,14 +83,14 @@ public class HorizontalPodAutoscalerIT {
     @Test
     @DisplayName("the detail page renders the horizontal pod autoscaler's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "horizontalpodautoscalers/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("horizontal pod autoscaler detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -152,22 +98,22 @@ public class HorizontalPodAutoscalerIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "horizontalpodautoscalers");
-      wait.until(d -> listHasHorizontalPodAutoscalerRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the horizontal pod autoscaler's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(HPA_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasHorizontalPodAutoscalerRow());
-      assertThat(listHasHorizontalPodAutoscalerRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("horizontal pod autoscaler row still present after delete")
         .isFalse();
     }
@@ -177,32 +123,25 @@ public class HorizontalPodAutoscalerIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "horizontalpodautoscalers/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted horizontal pod autoscaler")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/ingresses/IngressIT.java
+++ b/src/test/java/com/marcnuri/yakd/ingresses/IngressIT.java
@@ -16,76 +16,36 @@
  */
 package com.marcnuri.yakd.ingresses;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Ingress")
-public class IngressIT {
+public class IngressIT extends AbstractResourceIT<Ingress> {
 
-  private static final String NAMESPACE = "default";
-  private static final String INGRESS_NAME = "it-ingress";
   private static final String DETAIL_MARKER = "ingress-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().network().v1().ingresses().inNamespace(NAMESPACE)
-      .resource(ingress()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public IngressIT() {
+    super("ingresses");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().network().v1().ingresses().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Ingress ingress() {
+  @Override
+  protected Ingress resource(String name) {
     return new IngressBuilder()
       .withNewMetadata()
-        .withName(INGRESS_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -109,38 +69,24 @@ public class IngressIT {
       .build();
   }
 
-  private boolean listHasIngressRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(INGRESS_NAME));
-  }
-
-  private String seededUid() {
-    final Ingress seeded = kubernetes.getClient().network().v1().ingresses()
-      .inNamespace(NAMESPACE).withName(INGRESS_NAME).get();
-    assertThat(seeded).as("seeded ingress available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final Ingress ingress = kubernetes.getClient().network().v1().ingresses()
-      .inNamespace(NAMESPACE).withName(INGRESS_NAME).get();
-    if (ingress == null || ingress.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return ingress.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded ingress")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "ingresses");
+      openList();
 
-      wait.until(d -> listHasIngressRow());
-      assertThat(listHasIngressRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded ingress present in the list")
         .isTrue();
     }
@@ -148,14 +94,14 @@ public class IngressIT {
     @Test
     @DisplayName("the detail page renders the ingress's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "ingresses/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("ingress detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -163,22 +109,22 @@ public class IngressIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "ingresses");
-      wait.until(d -> listHasIngressRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the ingress's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(INGRESS_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasIngressRow());
-      assertThat(listHasIngressRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("ingress row still present after delete")
         .isFalse();
     }
@@ -188,32 +134,25 @@ public class IngressIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "ingresses/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted ingress")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/jobs/JobIT.java
+++ b/src/test/java/com/marcnuri/yakd/jobs/JobIT.java
@@ -16,76 +16,36 @@
  */
 package com.marcnuri.yakd.jobs;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Job")
-public class JobIT {
+public class JobIT extends AbstractResourceIT<Job> {
 
-  private static final String NAMESPACE = "default";
-  private static final String JOB_NAME = "it-job";
   private static final String DETAIL_MARKER = "job-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().batch().v1().jobs().inNamespace(NAMESPACE)
-      .resource(job()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public JobIT() {
+    super("jobs");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().batch().v1().jobs().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Job job() {
+  @Override
+  protected Job resource(String name) {
     return new JobBuilder()
       .withNewMetadata()
-        .withName(JOB_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -100,38 +60,24 @@ public class JobIT {
       .build();
   }
 
-  private boolean listHasJobRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(JOB_NAME));
-  }
-
-  private String seededUid() {
-    final Job seeded = kubernetes.getClient().batch().v1().jobs()
-      .inNamespace(NAMESPACE).withName(JOB_NAME).get();
-    assertThat(seeded).as("seeded job available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final Job job = kubernetes.getClient().batch().v1().jobs()
-      .inNamespace(NAMESPACE).withName(JOB_NAME).get();
-    if (job == null || job.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return job.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded job")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "jobs");
+      openList();
 
-      wait.until(d -> listHasJobRow());
-      assertThat(listHasJobRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded job present in the list")
         .isTrue();
     }
@@ -139,14 +85,14 @@ public class JobIT {
     @Test
     @DisplayName("the detail page renders the job's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "jobs/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("job detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -154,22 +100,22 @@ public class JobIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "jobs");
-      wait.until(d -> listHasJobRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the job's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(JOB_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasJobRow());
-      assertThat(listHasJobRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("job row still present after delete")
         .isFalse();
     }
@@ -179,32 +125,25 @@ public class JobIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "jobs/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted job")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/namespaces/NamespaceIT.java
+++ b/src/test/java/com/marcnuri/yakd/namespaces/NamespaceIT.java
@@ -16,100 +16,58 @@
  */
 package com.marcnuri.yakd.namespaces;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Namespace")
-public class NamespaceIT {
+public class NamespaceIT extends AbstractResourceIT<Namespace> {
 
-  private static final String NAMESPACE_NAME = "it-namespace";
   private static final String DETAIL_MARKER = "namespace-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().namespaces()
-      .resource(namespace()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public NamespaceIT() {
+    super("namespaces");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().namespaces().withName(NAMESPACE_NAME).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Namespace namespace() {
+  @Override
+  protected Namespace resource(String name) {
     return new NamespaceBuilder()
       .withNewMetadata()
-        .withName(NAMESPACE_NAME)
+        .withName(name)
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
       .build();
-  }
-
-  private boolean listHasNamespaceRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(NAMESPACE_NAME));
-  }
-
-  private String seededUid() {
-    final Namespace seeded = kubernetes.getClient().namespaces().withName(NAMESPACE_NAME).get();
-    assertThat(seeded).as("seeded namespace available").isNotNull();
-    return seeded.getMetadata().getUid();
   }
 
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded namespace")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "namespaces");
+      openList();
 
-      wait.until(d -> listHasNamespaceRow());
-      assertThat(listHasNamespaceRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded namespace present in the list")
         .isTrue();
     }
@@ -117,14 +75,14 @@ public class NamespaceIT {
     @Test
     @DisplayName("the detail page renders the namespace's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "namespaces/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("namespace detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -134,22 +92,22 @@ public class NamespaceIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "namespaces");
-      wait.until(d -> listHasNamespaceRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the namespace's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(NAMESPACE_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasNamespaceRow());
-      assertThat(listHasNamespaceRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("namespace row still present after delete")
         .isFalse();
     }

--- a/src/test/java/com/marcnuri/yakd/persistentvolumeclaims/PersistentVolumeClaimIT.java
+++ b/src/test/java/com/marcnuri/yakd/persistentvolumeclaims/PersistentVolumeClaimIT.java
@@ -16,77 +16,37 @@
  */
 package com.marcnuri.yakd.persistentvolumeclaims;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("PersistentVolumeClaim")
-public class PersistentVolumeClaimIT {
+public class PersistentVolumeClaimIT extends AbstractResourceIT<PersistentVolumeClaim> {
 
-  private static final String NAMESPACE = "default";
-  private static final String PVC_NAME = "it-persistent-volume-claim";
   private static final String DETAIL_MARKER = "persistent-volume-claim-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().persistentVolumeClaims().inNamespace(NAMESPACE)
-      .resource(persistentVolumeClaim()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public PersistentVolumeClaimIT() {
+    super("persistentvolumeclaims");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().persistentVolumeClaims().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static PersistentVolumeClaim persistentVolumeClaim() {
+  @Override
+  protected PersistentVolumeClaim resource(String name) {
     return new PersistentVolumeClaimBuilder()
       .withNewMetadata()
-        .withName(PVC_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -98,38 +58,24 @@ public class PersistentVolumeClaimIT {
       .build();
   }
 
-  private boolean listHasPersistentVolumeClaimRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(PVC_NAME));
-  }
-
-  private String seededUid() {
-    final PersistentVolumeClaim seeded = kubernetes.getClient().persistentVolumeClaims()
-      .inNamespace(NAMESPACE).withName(PVC_NAME).get();
-    assertThat(seeded).as("seeded persistent volume claim available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final PersistentVolumeClaim persistentVolumeClaim = kubernetes.getClient()
-      .persistentVolumeClaims().inNamespace(NAMESPACE).withName(PVC_NAME).get();
-    if (persistentVolumeClaim == null || persistentVolumeClaim.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return persistentVolumeClaim.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded persistent volume claim")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "persistentvolumeclaims");
+      openList();
 
-      wait.until(d -> listHasPersistentVolumeClaimRow());
-      assertThat(listHasPersistentVolumeClaimRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded persistent volume claim present in the list")
         .isTrue();
     }
@@ -137,14 +83,14 @@ public class PersistentVolumeClaimIT {
     @Test
     @DisplayName("the detail page renders the persistent volume claim's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "persistentvolumeclaims/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("persistent volume claim detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -152,22 +98,22 @@ public class PersistentVolumeClaimIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "persistentvolumeclaims");
-      wait.until(d -> listHasPersistentVolumeClaimRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the persistent volume claim's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(PVC_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasPersistentVolumeClaimRow());
-      assertThat(listHasPersistentVolumeClaimRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("persistent volume claim row still present after delete")
         .isFalse();
     }
@@ -177,32 +123,25 @@ public class PersistentVolumeClaimIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "persistentvolumeclaims/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted persistent volume claim")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/persistentvolumes/PersistentVolumeIT.java
+++ b/src/test/java/com/marcnuri/yakd/persistentvolumes/PersistentVolumeIT.java
@@ -16,78 +16,37 @@
  */
 package com.marcnuri.yakd.persistentvolumes;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.PersistentVolume;
 import io.fabric8.kubernetes.api.model.PersistentVolumeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("PersistentVolume")
-public class PersistentVolumeIT {
+public class PersistentVolumeIT extends AbstractResourceIT<PersistentVolume> {
 
-  private static final String PV_NAME = "it-persistent-volume";
-  private static final String ADDED_PV_NAME = "watch-added-persistent-volume";
   private static final String DETAIL_MARKER = "persistent-volume-detail-marker";
   private static final String MODIFIED_PHASE = "Released";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().persistentVolumes()
-      .resource(persistentVolume(PV_NAME)).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public PersistentVolumeIT() {
+    super("persistentvolumes");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().persistentVolumes().withName(PV_NAME).delete();
-    kubernetes.getClient().persistentVolumes().withName(ADDED_PV_NAME).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static PersistentVolume persistentVolume(String pvName) {
+  @Override
+  protected PersistentVolume resource(String name) {
     return new PersistentVolumeBuilder()
       .withNewMetadata()
-        .withName(pvName)
+        .withName(name)
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -96,49 +55,30 @@ public class PersistentVolumeIT {
         .withAccessModes("ReadWriteOnce")
         .withStorageClassName("it-storage-class")
         .withPersistentVolumeReclaimPolicy("Retain")
-        .withNewHostPath().withPath("/tmp/" + pvName).endHostPath()
+        .withNewHostPath().withPath("/tmp/" + name).endHostPath()
       .endSpec()
       .withNewStatus().withPhase("Available").endStatus()
       .build();
-  }
-
-  private boolean listHasRow(String pvName) {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(pvName));
-  }
-
-  private boolean persistentVolumeRowShowsPhase(String phase) {
-    return driver.findElements(ROW).stream()
-      .filter(row -> row.getText().contains(PV_NAME))
-      .anyMatch(row -> row.getText().contains(phase));
-  }
-
-  private String seededUid() {
-    final PersistentVolume seeded = kubernetes.getClient().persistentVolumes().withName(PV_NAME).get();
-    assertThat(seeded).as("seeded persistent volume available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final PersistentVolume persistentVolume = kubernetes.getClient().persistentVolumes()
-      .withName(PV_NAME).get();
-    if (persistentVolume == null || persistentVolume.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return persistentVolume.getMetadata().getLabels().get("mutation-marker");
   }
 
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded persistent volume")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "persistentvolumes");
+      openList();
 
-      wait.until(d -> listHasRow(PV_NAME));
-      assertThat(listHasRow(PV_NAME))
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded persistent volume present in the list")
         .isTrue();
     }
@@ -146,14 +86,14 @@ public class PersistentVolumeIT {
     @Test
     @DisplayName("the detail page renders the persistent volume's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "persistentvolumes/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("persistent volume detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -161,22 +101,22 @@ public class PersistentVolumeIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "persistentvolumes");
-      wait.until(d -> listHasRow(PV_NAME));
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the persistent volume's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(PV_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasRow(PV_NAME));
-      assertThat(listHasRow(PV_NAME))
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("persistent volume row still present after delete")
         .isFalse();
     }
@@ -186,32 +126,25 @@ public class PersistentVolumeIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "persistentvolumes/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted persistent volume")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 
@@ -219,22 +152,25 @@ public class PersistentVolumeIT {
   @DisplayName("when the server pushes live watch events")
   class WatchLiveUpdates {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "persistentvolumes");
+      name = seed("to-watch");
+      openList();
       // Waiting for the seeded row guarantees the watch stream is connected and its
       // initial sync replayed before the test mutates the cluster, so any later change
       // can only reach the list through a live watch event.
-      wait.until(d -> listHasRow(PV_NAME));
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("a persistent volume created server-side appears in the list without a refresh")
     void createdPersistentVolumeAppears() {
-      kubernetes.getClient().persistentVolumes().resource(persistentVolume(ADDED_PV_NAME)).create();
+      final String added = seed("watch-added");
 
-      wait.until(d -> listHasRow(ADDED_PV_NAME));
-      assertThat(listHasRow(ADDED_PV_NAME))
+      awaitRow(added);
+      assertThat(hasRow(added))
         .as("row for the server-side-created persistent volume present in the list")
         .isTrue();
     }
@@ -242,10 +178,10 @@ public class PersistentVolumeIT {
     @Test
     @DisplayName("a persistent volume deleted server-side disappears from the list without a refresh")
     void deletedPersistentVolumeDisappears() {
-      kubernetes.getClient().persistentVolumes().withName(PV_NAME).delete();
+      kubernetes.getClient().persistentVolumes().withName(name).delete();
 
-      wait.until(d -> !listHasRow(PV_NAME));
-      assertThat(listHasRow(PV_NAME))
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("row for the server-side-deleted persistent volume still present in the list")
         .isFalse();
     }
@@ -253,13 +189,13 @@ public class PersistentVolumeIT {
     @Test
     @DisplayName("a persistent volume modified server-side updates its row in place without a refresh")
     void modifiedPersistentVolumeUpdatesRow() {
-      kubernetes.getClient().persistentVolumes().withName(PV_NAME)
+      kubernetes.getClient().persistentVolumes().withName(name)
         .edit(pv -> new PersistentVolumeBuilder(pv)
           .editOrNewStatus().withPhase(MODIFIED_PHASE).endStatus()
           .build());
 
-      wait.until(d -> persistentVolumeRowShowsPhase(MODIFIED_PHASE));
-      assertThat(persistentVolumeRowShowsPhase(MODIFIED_PHASE))
+      await(() -> rowShows(name, MODIFIED_PHASE));
+      assertThat(rowShows(name, MODIFIED_PHASE))
         .as("persistent volume row reflects the server-side phase change")
         .isTrue();
     }

--- a/src/test/java/com/marcnuri/yakd/replicationcontrollers/ReplicationControllerIT.java
+++ b/src/test/java/com/marcnuri/yakd/replicationcontrollers/ReplicationControllerIT.java
@@ -16,84 +16,44 @@
  */
 package com.marcnuri.yakd.replicationcontrollers;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("ReplicationController")
-public class ReplicationControllerIT {
+public class ReplicationControllerIT extends AbstractResourceIT<ReplicationController> {
 
-  private static final String NAMESPACE = "default";
-  private static final String RC_NAME = "it-replication-controller";
   private static final String DETAIL_MARKER = "replication-controller-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().replicationControllers().inNamespace(NAMESPACE)
-      .resource(replicationController()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public ReplicationControllerIT() {
+    super("replicationcontrollers");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().replicationControllers().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static ReplicationController replicationController() {
+  @Override
+  protected ReplicationController resource(String name) {
     return new ReplicationControllerBuilder()
       .withNewMetadata()
-        .withName(RC_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
       .withNewSpec()
         .withReplicas(1)
-        .addToSelector("app", RC_NAME)
+        .addToSelector("app", name)
         .withNewTemplate()
-          .withNewMetadata().addToLabels("app", RC_NAME).endMetadata()
+          .withNewMetadata().addToLabels("app", name).endMetadata()
           .withNewSpec()
             .addNewContainer().withName("container-1").withImage("busybox").endContainer()
           .endSpec()
@@ -102,38 +62,24 @@ public class ReplicationControllerIT {
       .build();
   }
 
-  private boolean listHasReplicationControllerRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(RC_NAME));
-  }
-
-  private String seededUid() {
-    final ReplicationController seeded = kubernetes.getClient().replicationControllers()
-      .inNamespace(NAMESPACE).withName(RC_NAME).get();
-    assertThat(seeded).as("seeded replication controller available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final ReplicationController replicationController = kubernetes.getClient()
-      .replicationControllers().inNamespace(NAMESPACE).withName(RC_NAME).get();
-    if (replicationController == null || replicationController.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return replicationController.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded replication controller")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "replicationcontrollers");
+      openList();
 
-      wait.until(d -> listHasReplicationControllerRow());
-      assertThat(listHasReplicationControllerRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded replication controller present in the list")
         .isTrue();
     }
@@ -141,14 +87,14 @@ public class ReplicationControllerIT {
     @Test
     @DisplayName("the detail page renders the replication controller's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "replicationcontrollers/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("replication controller detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -156,22 +102,22 @@ public class ReplicationControllerIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "replicationcontrollers");
-      wait.until(d -> listHasReplicationControllerRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the replication controller's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(RC_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasReplicationControllerRow());
-      assertThat(listHasReplicationControllerRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("replication controller row still present after delete")
         .isFalse();
     }
@@ -181,32 +127,25 @@ public class ReplicationControllerIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "replicationcontrollers/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted replication controller")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/rolebindings/RoleBindingIT.java
+++ b/src/test/java/com/marcnuri/yakd/rolebindings/RoleBindingIT.java
@@ -16,76 +16,36 @@
  */
 package com.marcnuri.yakd.rolebindings;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("RoleBinding")
-public class RoleBindingIT {
+public class RoleBindingIT extends AbstractResourceIT<RoleBinding> {
 
-  private static final String NAMESPACE = "default";
-  private static final String ROLE_BINDING_NAME = "it-role-binding";
   private static final String DETAIL_MARKER = "role-binding-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().rbac().roleBindings().inNamespace(NAMESPACE)
-      .resource(roleBinding()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public RoleBindingIT() {
+    super("rolebindings");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().rbac().roleBindings().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static RoleBinding roleBinding() {
+  @Override
+  protected RoleBinding resource(String name) {
     return new RoleBindingBuilder()
       .withNewMetadata()
-        .withName(ROLE_BINDING_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -98,38 +58,24 @@ public class RoleBindingIT {
       .build();
   }
 
-  private boolean listHasRoleBindingRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(ROLE_BINDING_NAME));
-  }
-
-  private String seededUid() {
-    final RoleBinding seeded = kubernetes.getClient().rbac().roleBindings()
-      .inNamespace(NAMESPACE).withName(ROLE_BINDING_NAME).get();
-    assertThat(seeded).as("seeded role binding available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final RoleBinding roleBinding = kubernetes.getClient().rbac().roleBindings()
-      .inNamespace(NAMESPACE).withName(ROLE_BINDING_NAME).get();
-    if (roleBinding == null || roleBinding.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return roleBinding.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded role binding")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "rolebindings");
+      openList();
 
-      wait.until(d -> listHasRoleBindingRow());
-      assertThat(listHasRoleBindingRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded role binding present in the list")
         .isTrue();
     }
@@ -137,14 +83,14 @@ public class RoleBindingIT {
     @Test
     @DisplayName("the detail page renders the role binding's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "rolebindings/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("role binding detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -152,22 +98,22 @@ public class RoleBindingIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "rolebindings");
-      wait.until(d -> listHasRoleBindingRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the role binding's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(ROLE_BINDING_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasRoleBindingRow());
-      assertThat(listHasRoleBindingRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("role binding row still present after delete")
         .isFalse();
     }
@@ -177,32 +123,25 @@ public class RoleBindingIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "rolebindings/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted role binding")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/roles/RoleIT.java
+++ b/src/test/java/com/marcnuri/yakd/roles/RoleIT.java
@@ -16,76 +16,36 @@
  */
 package com.marcnuri.yakd.roles;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Role")
-public class RoleIT {
+public class RoleIT extends AbstractResourceIT<Role> {
 
-  private static final String NAMESPACE = "default";
-  private static final String ROLE_NAME = "it-role";
   private static final String DETAIL_MARKER = "role-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().rbac().roles().inNamespace(NAMESPACE)
-      .resource(role()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public RoleIT() {
+    super("roles");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().rbac().roles().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Role role() {
+  @Override
+  protected Role resource(String name) {
     return new RoleBuilder()
       .withNewMetadata()
-        .withName(ROLE_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
@@ -95,38 +55,24 @@ public class RoleIT {
       .build();
   }
 
-  private boolean listHasRoleRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(ROLE_NAME));
-  }
-
-  private String seededUid() {
-    final Role seeded = kubernetes.getClient().rbac().roles()
-      .inNamespace(NAMESPACE).withName(ROLE_NAME).get();
-    assertThat(seeded).as("seeded role available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final Role role = kubernetes.getClient().rbac().roles()
-      .inNamespace(NAMESPACE).withName(ROLE_NAME).get();
-    if (role == null || role.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return role.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded role")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "roles");
+      openList();
 
-      wait.until(d -> listHasRoleRow());
-      assertThat(listHasRoleRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded role present in the list")
         .isTrue();
     }
@@ -134,14 +80,14 @@ public class RoleIT {
     @Test
     @DisplayName("the detail page renders the role's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "roles/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("role detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -149,22 +95,22 @@ public class RoleIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "roles");
-      wait.until(d -> listHasRoleRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the role's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(ROLE_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasRoleRow());
-      assertThat(listHasRoleRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("role row still present after delete")
         .isFalse();
     }
@@ -174,32 +120,25 @@ public class RoleIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "roles/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted role")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/secrets/SecretIT.java
+++ b/src/test/java/com/marcnuri/yakd/secrets/SecretIT.java
@@ -16,32 +16,18 @@
  */
 package com.marcnuri.yakd.secrets;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
 
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,45 +35,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Secret")
-public class SecretIT {
+public class SecretIT extends AbstractResourceIT<Secret> {
 
-  private static final String NAMESPACE = "default";
-  private static final String SECRET_NAME = "it-secret";
   private static final String DECODED_VALUE = "secret-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().secrets().inNamespace(NAMESPACE)
-      .resource(secret()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public SecretIT() {
+    super("secrets");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().secrets().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Secret secret() {
+  @Override
+  protected Secret resource(String name) {
     return new SecretBuilder()
       .withNewMetadata()
-        .withName(SECRET_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
       .endMetadata()
       .withType("Opaque")
@@ -96,53 +57,39 @@ public class SecretIT {
       .build();
   }
 
-  private boolean listHasSecretRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(SECRET_NAME));
-  }
-
-  private String seededUid() {
-    final Secret seeded = kubernetes.getClient().secrets()
-      .inNamespace(NAMESPACE).withName(SECRET_NAME).get();
-    assertThat(seeded).as("seeded secret available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final Secret secret = kubernetes.getClient().secrets()
-      .inNamespace(NAMESPACE).withName(SECRET_NAME).get();
-    if (secret == null || secret.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return secret.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded secret")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "secrets");
+      openList();
 
-      wait.until(d -> listHasSecretRow());
-      assertThat(listHasSecretRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded secret present in the list")
         .isTrue();
     }
 
     @Test
     @DisplayName("the detail page renders the secret's base64-decoded data value")
-    void detailRendersDecodedValue() {
-      driver.navigate().to(url.toString() + "secrets/" + seededUid());
+    void detailRendersDataValue() {
+      openDetail(seededUid(name));
 
       // The page only ever shows the atob-decoded form, so the cleartext can only
       // appear if the detail page decoded the seeded resource's base64 data value.
-      wait.until(d -> d.getPageSource().contains(DECODED_VALUE));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DECODED_VALUE);
+      assertThat(pageContains(DECODED_VALUE))
         .as("secret detail page contents")
-        .contains(DECODED_VALUE);
+        .isTrue();
     }
   }
 
@@ -150,22 +97,22 @@ public class SecretIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "secrets");
-      wait.until(d -> listHasSecretRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the secret's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(SECRET_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasSecretRow());
-      assertThat(listHasSecretRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("secret row still present after delete")
         .isFalse();
     }
@@ -175,32 +122,25 @@ public class SecretIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "secrets/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted secret")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/selenium/AbstractResourceIT.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/AbstractResourceIT.java
@@ -45,13 +45,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * which keys off the object's own metadata, so the same code serves both namespaced and
  * cluster-scoped resources.
  *
- * <p><strong>Naming &amp; isolation.</strong> The constructor derives a per-class random base name;
- * {@link #seed(String)} appends a behavior suffix (e.g. {@code "to-delete"}), so every test seeds a
- * distinctly-named resource and no two tests in a class share backend state. This keeps the tests
- * mutually independent and is a prerequisite for a possible future experiment running them
- * concurrently within a class — note that actually enabling {@code @Execution(CONCURRENT)} would
- * additionally require a WebDriver per test/thread, as the one injected here is shared and Selenium
- * drivers are not thread-safe.
+ * <p><strong>Naming &amp; isolation.</strong> The constructor derives a random base name; under the
+ * default {@code PER_METHOD} lifecycle the class is instantiated once per {@code @Test}, so the base
+ * is re-randomized for every test, not shared across a class. {@link #seed(String)} appends a
+ * behavior suffix (e.g. {@code "to-delete"}), so every test seeds a distinctly-named resource and no
+ * two tests share backend state. This keeps the tests mutually independent and is a prerequisite for
+ * a possible future experiment running them concurrently within a class — note that actually
+ * enabling {@code @Execution(CONCURRENT)} would additionally require a WebDriver per test/thread, as
+ * the one injected here is shared and Selenium drivers are not thread-safe.
  *
  * @param <T> the Kubernetes resource type under test
  */

--- a/src/test/java/com/marcnuri/yakd/selenium/AbstractResourceIT.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/AbstractResourceIT.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.selenium;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.openqa.selenium.WebDriver;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base for the per-resource Selenium integration tests. It owns everything that is invariant
+ * across resources — the injected {@link WebDriver}/{@link KubernetesServer}/URL, the
+ * {@link ResourceUi} plumbing, the browser-tab lifecycle, and the generic backend helpers
+ * (seed/uid/label) — but deliberately declares <strong>no</strong> {@code @Nested} groups or
+ * {@code @Test} methods: each subclass keeps its full, visible spec so the file reads on its own.
+ *
+ * <p>The single resource-specific contract is {@link #resource(String)}, a builder for the type
+ * under test. Seeding, fetching and deleting are scope-agnostic via {@code client.resource(obj)},
+ * which keys off the object's own metadata, so the same code serves both namespaced and
+ * cluster-scoped resources.
+ *
+ * <p><strong>Naming &amp; isolation.</strong> The constructor derives a per-class random base name;
+ * {@link #seed(String)} appends a behavior suffix (e.g. {@code "to-delete"}), so every test seeds a
+ * distinctly-named resource and no two tests in a class share backend state. This keeps the tests
+ * mutually independent and is a prerequisite for a possible future experiment running them
+ * concurrently within a class — note that actually enabling {@code @Execution(CONCURRENT)} would
+ * additionally require a WebDriver per test/thread, as the one injected here is shared and Selenium
+ * drivers are not thread-safe.
+ *
+ * @param <T> the Kubernetes resource type under test
+ */
+public abstract class AbstractResourceIT<T extends HasMetadata> {
+
+  @KubernetesTestServer
+  protected KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+
+  // Exposed to subclasses so resource-specific groups (e.g. scale carets, the cronjob suspend
+  // toggle, sidebar nav) can drive bespoke elements the shared delegates do not cover.
+  protected WebDriver driver;
+
+  protected ResourceUi ui;
+
+  private final String route;
+  private final String base;
+  private final List<T> seeded = new ArrayList<>();
+
+  protected AbstractResourceIT(String route) {
+    this.route = route;
+    this.base = route + "-" + UUID.randomUUID().toString().substring(0, 8);
+  }
+
+  /** Builds a resource of the type under test carrying the given name. */
+  protected abstract T resource(String name);
+
+  // --- lifecycle ---
+
+  @BeforeEach
+  void openTab() {
+    ui = ResourceUi.openTab(driver, url);
+  }
+
+  @AfterEach
+  void closeTabAndCleanup() {
+    try {
+      // The mock server outlives the test class, so delete everything this test seeded. Do this
+      // first (and in a finally) so a failure to close the tab cannot leak resources.
+      seeded.forEach(resource -> kubernetes.getClient().resource(resource).delete());
+      seeded.clear();
+    } finally {
+      if (ui != null) {
+        ui.closeTab();
+      }
+    }
+  }
+
+  // --- backend helpers (scope-agnostic via client.resource(obj)) ---
+
+  /** Seeds a uniquely-named resource ({@code <base>-<suffix>}) and returns its name. */
+  protected String seed(String suffix) {
+    final T resource = resource(base + "-" + suffix);
+    kubernetes.getClient().resource(resource).createOr(NonDeletingOperation::update);
+    seeded.add(resource);
+    return resource.getMetadata().getName();
+  }
+
+  /** The server-assigned uid of a previously {@link #seed(String) seeded} resource. */
+  protected String seededUid(String name) {
+    final HasMetadata stored = fetch(name);
+    assertThat(stored).as("seeded %s available", route).isNotNull();
+    return stored.getMetadata().getUid();
+  }
+
+  /**
+   * The current value of a metadata label on a previously {@link #seed(String) seeded} resource,
+   * or {@code null}.
+   */
+  protected String label(String name, String key) {
+    final HasMetadata stored = fetch(name);
+    if (stored == null || stored.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return stored.getMetadata().getLabels().get(key);
+  }
+
+  // Re-reads the server copy of a resource this test seeded via seed(...); resolves only names
+  // returned by seed(), so seededUid/label do not see resources created by raw client calls.
+  private HasMetadata fetch(String name) {
+    return seeded.stream()
+      .filter(resource -> name.equals(resource.getMetadata().getName()))
+      .findFirst()
+      .map(resource -> kubernetes.getClient().resource(resource).get())
+      .orElse(null);
+  }
+
+  // --- UI delegates (route pre-bound so the subclass spec stays terse) ---
+
+  /** Navigates to an arbitrary application path (e.g. {@code ""} for the dashboard, {@code "search"}). */
+  protected void open(String path) {
+    ui.open(path);
+  }
+
+  protected void openList() {
+    ui.openList(route);
+  }
+
+  protected void openDetail(String uid) {
+    ui.openDetail(route, uid);
+  }
+
+  protected void openEditor(String uid) {
+    ui.openEditor(route, uid);
+  }
+
+  protected boolean hasRow(String name) {
+    return ui.hasRow(name);
+  }
+
+  protected boolean rowShows(String name, String text) {
+    return ui.rowShows(name, text);
+  }
+
+  protected void deleteRow(String name) {
+    ui.deleteRow(name);
+  }
+
+  protected void awaitRow(String name) {
+    ui.await(() -> ui.hasRow(name));
+  }
+
+  protected void awaitNoRow(String name) {
+    ui.await(() -> !ui.hasRow(name));
+  }
+
+  protected boolean pageContains(String text) {
+    return ui.pageContains(text);
+  }
+
+  protected void awaitPageContains(String text) {
+    ui.await(() -> ui.pageContains(text));
+  }
+
+  protected void awaitEditorContains(String text) {
+    ui.await(() -> ui.editorContains(text));
+  }
+
+  /** Polls an arbitrary backend/UI condition until it holds or the timeout elapses. */
+  protected void await(BooleanSupplier condition) {
+    ui.await(condition);
+  }
+
+  protected void editorReplace(String from, String to) {
+    ui.editorReplace(from, to);
+  }
+
+  protected void save() {
+    ui.save();
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/selenium/OpenShiftDiscovery.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/OpenShiftDiscovery.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.selenium;
+
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+
+/**
+ * Seeds the discovery responses that flip the application into OpenShift mode and let it subscribe
+ * the Route/DeploymentConfig watchers. Because these expectations are always-on and change app-wide
+ * behavior, ITs that use them must run on the dedicated {@link OpenShiftIntegrationTestProfile} so
+ * they cannot leak into vanilla-Kubernetes classes sharing the default profile.
+ */
+public final class OpenShiftDiscovery {
+
+  private OpenShiftDiscovery() {
+  }
+
+  public static void advertise(KubernetesServer kubernetes) {
+    // The frontend flips to OpenShift mode when the backend reports an *.openshift.io API group
+    // (served from the cluster's /apis discovery).
+    kubernetes.expect().get().withPath("/apis").andReturn(200, new APIGroupListBuilder()
+        .addToGroups(new APIGroupBuilder().withName("route.openshift.io").build())
+        .addToGroups(new APIGroupBuilder().withName("apps.openshift.io").build())
+        .build())
+      .always();
+    // The backend only subscribes its Route/DeploymentConfig watchers when the cluster's version
+    // discovery reports the resource as supported.
+    kubernetes.expect().get().withPath("/apis/route.openshift.io/v1").andReturn(200, new APIResourceListBuilder()
+        .withGroupVersion("route.openshift.io/v1")
+        .addNewResource().withName("routes").withKind("Route").withNamespaced(true).endResource()
+        .build())
+      .always();
+    kubernetes.expect().get().withPath("/apis/apps.openshift.io/v1").andReturn(200, new APIResourceListBuilder()
+        .withGroupVersion("apps.openshift.io/v1")
+        .addNewResource().withName("deploymentconfigs").withKind("DeploymentConfig").withNamespaced(true).endResource()
+        .build())
+      .always();
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/selenium/RbacDiscovery.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/RbacDiscovery.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.selenium;
+
+import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+
+/**
+ * Seeds the discovery response the application needs before it will subscribe to the cluster-scoped
+ * RBAC watchers (ClusterRole, ClusterRoleBinding). Those watchers only subscribe when the cluster's
+ * discovery reports the resource as supported, and the CRUD mock does not advertise them by default.
+ *
+ * <p>Because this expectation is always-on and the mock server outlives a test class, the RBAC ITs
+ * run on the dedicated {@link RbacIntegrationTestProfile} so it cannot leak into vanilla-mode classes.
+ */
+public final class RbacDiscovery {
+
+  private RbacDiscovery() {
+  }
+
+  public static void advertise(KubernetesServer kubernetes) {
+    kubernetes.expect().get().withPath("/apis/rbac.authorization.k8s.io/v1")
+      .andReturn(200, new APIResourceListBuilder()
+        .withGroupVersion("rbac.authorization.k8s.io/v1")
+        .addNewResource().withName("clusterroles").withKind("ClusterRole").withNamespaced(false).endResource()
+        .addNewResource().withName("clusterrolebindings").withKind("ClusterRoleBinding").withNamespaced(false).endResource()
+        .addNewResource().withName("roles").withKind("Role").withNamespaced(true).endResource()
+        .addNewResource().withName("rolebindings").withKind("RoleBinding").withNamespaced(true).endResource()
+        .build())
+      .always();
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/selenium/ResourceUi.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/ResourceUi.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.selenium;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Page object that encapsulates the WebDriver plumbing shared by the Selenium integration tests:
+ * an isolated browser tab per test, a tuned {@link FluentWait}, and the {@code data-testid} based
+ * queries and actions for the shared resource list, detail and YAML-editor pages.
+ *
+ * <p>It holds no resource knowledge, so it is usable by any Selenium IT, not only those extending
+ * {@link AbstractResourceIT}.
+ */
+public class ResourceUi {
+
+  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
+  private static final By ROW_DELETE = By.cssSelector("[data-testid='resource-list__delete']");
+  private static final By EDIT_SAVE = By.cssSelector("[data-testid='resource-edit__save']");
+
+  private final WebDriver driver;
+  private final URL url;
+  private final Wait<WebDriver> wait;
+
+  private ResourceUi(WebDriver driver, URL url) {
+    this.driver = driver;
+    this.url = url;
+    this.wait = new FluentWait<>(driver)
+      .withTimeout(Duration.ofSeconds(10))
+      .pollingEvery(Duration.ofMillis(100))
+      .ignoring(NoSuchElementException.class)
+      .ignoring(StaleElementReferenceException.class);
+  }
+
+  /**
+   * Opens a fresh, isolated browser tab (a clean Redux store and watch streams per test) and
+   * returns a {@code ResourceUi} bound to it. Pair every call with {@link #closeTab()}.
+   */
+  public static ResourceUi openTab(WebDriver driver, URL url) {
+    driver.switchTo().newWindow(WindowType.TAB);
+    return new ResourceUi(driver, url);
+  }
+
+  /** Closes the current tab and switches back to the first remaining window. */
+  public void closeTab() {
+    driver.close();
+    driver.switchTo().window(driver.getWindowHandles().iterator().next());
+  }
+
+  // --- navigation ---
+
+  /** Navigates to an arbitrary application path (e.g. {@code ""} for the dashboard, {@code "search"}). */
+  public void open(String path) {
+    driver.navigate().to(url.toString() + path);
+  }
+
+  public void openList(String route) {
+    open(route);
+  }
+
+  public void openDetail(String route, String uid) {
+    open(route + "/" + uid);
+  }
+
+  public void openEditor(String route, String uid) {
+    open(route + "/" + uid + "/edit");
+  }
+
+  // --- waiting ---
+
+  /** Polls {@code condition} until it holds or the timeout elapses. */
+  public void await(BooleanSupplier condition) {
+    wait.until(d -> condition.getAsBoolean());
+  }
+
+  // --- list queries ---
+
+  public boolean hasRow(String name) {
+    return driver.findElements(ROW).stream().anyMatch(row -> row.getText().contains(name));
+  }
+
+  /** Whether the row matching {@code name} also shows {@code text} (e.g. an image or phase). */
+  public boolean rowShows(String name, String text) {
+    return driver.findElements(ROW).stream()
+      .filter(row -> row.getText().contains(name))
+      .anyMatch(row -> row.getText().contains(text));
+  }
+
+  // --- list actions ---
+
+  public void deleteRow(String name) {
+    driver.findElements(ROW).stream()
+      .filter(row -> row.getText().contains(name))
+      .findFirst().orElseThrow()
+      .findElement(ROW_DELETE).click();
+  }
+
+  // --- detail ---
+
+  public boolean pageContains(String text) {
+    return driver.getPageSource().contains(text);
+  }
+
+  // --- YAML editor ---
+
+  public boolean editorContains(String text) {
+    return editorValue().contains(text);
+  }
+
+  public String editorValue() {
+    final Object value = ((JavascriptExecutor) driver).executeScript(
+      "const e = document.querySelector('.ace_editor');"
+        + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
+    return value == null ? "" : value.toString();
+  }
+
+  public void editorReplace(String from, String to) {
+    ((JavascriptExecutor) driver).executeScript(
+      "const ed = document.querySelector('.ace_editor').env.editor;"
+        + "ed.setValue(ed.getValue().replace(arguments[0], arguments[1]), 1);", from, to);
+  }
+
+  public void save() {
+    driver.findElement(EDIT_SAVE).click();
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/service/ServiceIT.java
+++ b/src/test/java/com/marcnuri/yakd/service/ServiceIT.java
@@ -16,119 +16,65 @@
  */
 package com.marcnuri.yakd.service;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("Service")
-public class ServiceIT {
+public class ServiceIT extends AbstractResourceIT<Service> {
 
-  private static final String NAMESPACE = "default";
-  private static final String SERVICE_NAME = "it-service";
   private static final String CLUSTER_IP = "10.20.30.40";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().services().inNamespace(NAMESPACE)
-      .resource(service()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public ServiceIT() {
+    super("services");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().services().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static Service service() {
+  @Override
+  protected Service resource(String name) {
     return new ServiceBuilder()
       .withNewMetadata()
-        .withName(SERVICE_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
       .endMetadata()
       .withNewSpec()
         .withType("ClusterIP")
         .withClusterIP(CLUSTER_IP)
-        .addToSelector("app", SERVICE_NAME)
+        .addToSelector("app", name)
         .addNewPort().withPort(80).withProtocol("TCP").endPort()
       .endSpec()
       .build();
-  }
-
-  private boolean listHasServiceRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(SERVICE_NAME));
-  }
-
-  private String seededUid() {
-    final Service seeded = kubernetes.getClient().services()
-      .inNamespace(NAMESPACE).withName(SERVICE_NAME).get();
-    assertThat(seeded).as("seeded service available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final Service service = kubernetes.getClient().services()
-      .inNamespace(NAMESPACE).withName(SERVICE_NAME).get();
-    if (service == null || service.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return service.getMetadata().getLabels().get("mutation-marker");
   }
 
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded service")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "services");
+      openList();
 
-      wait.until(d -> listHasServiceRow());
-      assertThat(listHasServiceRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded service present in the list")
         .isTrue();
     }
@@ -136,14 +82,14 @@ public class ServiceIT {
     @Test
     @DisplayName("the detail page renders the service's cluster IP")
     void detailRendersClusterIp() {
-      driver.navigate().to(url.toString() + "services/" + seededUid());
+      openDetail(seededUid(name));
 
       // The cluster IP can only come from the seeded resource's spec, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(CLUSTER_IP));
-      assertThat(driver.getPageSource())
+      awaitPageContains(CLUSTER_IP);
+      assertThat(pageContains(CLUSTER_IP))
         .as("service detail page contents")
-        .contains(CLUSTER_IP);
+        .isTrue();
     }
   }
 
@@ -151,22 +97,22 @@ public class ServiceIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "services");
-      wait.until(d -> listHasServiceRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the service's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(SERVICE_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasServiceRow());
-      assertThat(listHasServiceRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("service row still present after delete")
         .isFalse();
     }
@@ -176,32 +122,25 @@ public class ServiceIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "services/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted service")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/serviceaccounts/ServiceAccountIT.java
+++ b/src/test/java/com/marcnuri/yakd/serviceaccounts/ServiceAccountIT.java
@@ -16,114 +16,60 @@
  */
 package com.marcnuri.yakd.serviceaccounts;
 
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServer;
-import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.net.URL;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 @DisplayName("ServiceAccount")
-public class ServiceAccountIT {
+public class ServiceAccountIT extends AbstractResourceIT<ServiceAccount> {
 
-  private static final String NAMESPACE = "default";
-  private static final String SERVICE_ACCOUNT_NAME = "it-service-account";
   private static final String DETAIL_MARKER = "service-account-detail-marker";
-  private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
 
-  @KubernetesTestServer
-  KubernetesServer kubernetes;
-
-  @TestHTTPResource
-  URL url;
-  WebDriver driver;
-  Wait<WebDriver> wait;
-
-  @BeforeEach
-  void setUp() {
-    wait = new FluentWait<>(driver)
-      .withTimeout(Duration.ofSeconds(10))
-      .pollingEvery(Duration.ofMillis(100))
-      .ignoring(NoSuchElementException.class)
-      .ignoring(StaleElementReferenceException.class);
-    kubernetes.getClient().serviceAccounts().inNamespace(NAMESPACE)
-      .resource(serviceAccount()).createOr(NonDeletingOperation::update);
-    driver.switchTo().newWindow(WindowType.TAB);
+  public ServiceAccountIT() {
+    super("serviceaccounts");
   }
 
-  @AfterEach
-  void tearDown() {
-    kubernetes.getClient().serviceAccounts().inNamespace(NAMESPACE).delete();
-    driver.close();
-    driver.switchTo().window(driver.getWindowHandles().iterator().next());
-  }
-
-  private static ServiceAccount serviceAccount() {
+  @Override
+  protected ServiceAccount resource(String name) {
     return new ServiceAccountBuilder()
       .withNewMetadata()
-        .withName(SERVICE_ACCOUNT_NAME)
-        .withNamespace(NAMESPACE)
+        .withName(name)
+        .withNamespace("default")
         .addToLabels("mutation-marker", "before-edit")
         .addToLabels("detail-marker", DETAIL_MARKER)
       .endMetadata()
       .build();
   }
 
-  private boolean listHasServiceAccountRow() {
-    return driver.findElements(ROW).stream()
-      .anyMatch(row -> row.getText().contains(SERVICE_ACCOUNT_NAME));
-  }
-
-  private String seededUid() {
-    final ServiceAccount seeded = kubernetes.getClient().serviceAccounts()
-      .inNamespace(NAMESPACE).withName(SERVICE_ACCOUNT_NAME).get();
-    assertThat(seeded).as("seeded service account available").isNotNull();
-    return seeded.getMetadata().getUid();
-  }
-
-  private String backendMarker() {
-    final ServiceAccount serviceAccount = kubernetes.getClient().serviceAccounts()
-      .inNamespace(NAMESPACE).withName(SERVICE_ACCOUNT_NAME).get();
-    if (serviceAccount == null || serviceAccount.getMetadata().getLabels() == null) {
-      return null;
-    }
-    return serviceAccount.getMetadata().getLabels().get("mutation-marker");
-  }
-
   @Nested
   @DisplayName("when viewing the list and detail pages")
   class ListAndDetail {
 
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
     @Test
     @DisplayName("the list renders a row for the seeded service account")
     void listRendersSeededRow() {
-      driver.navigate().to(url.toString() + "serviceaccounts");
+      openList();
 
-      wait.until(d -> listHasServiceAccountRow());
-      assertThat(listHasServiceAccountRow())
+      awaitRow(name);
+      assertThat(hasRow(name))
         .as("row for the seeded service account present in the list")
         .isTrue();
     }
@@ -131,14 +77,14 @@ public class ServiceAccountIT {
     @Test
     @DisplayName("the detail page renders the service account's label")
     void detailRendersLabel() {
-      driver.navigate().to(url.toString() + "serviceaccounts/" + seededUid());
+      openDetail(seededUid(name));
 
       // The label value can only come from the seeded resource's metadata, so its
       // presence proves the detail page rendered the resource loaded via the watch.
-      wait.until(d -> d.getPageSource().contains(DETAIL_MARKER));
-      assertThat(driver.getPageSource())
+      awaitPageContains(DETAIL_MARKER);
+      assertThat(pageContains(DETAIL_MARKER))
         .as("service account detail page contents")
-        .contains(DETAIL_MARKER);
+        .isTrue();
     }
   }
 
@@ -146,22 +92,22 @@ public class ServiceAccountIT {
   @DisplayName("when deleting from the list page")
   class DeleteFromList {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "serviceaccounts");
-      wait.until(d -> listHasServiceAccountRow());
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
     }
 
     @Test
     @DisplayName("clicking delete removes the service account's row from the list")
     void deleteRemovesRow() {
-      driver.findElements(ROW).stream()
-        .filter(row -> row.getText().contains(SERVICE_ACCOUNT_NAME))
-        .findFirst().orElseThrow()
-        .findElement(By.cssSelector("[data-testid='resource-list__delete']")).click();
+      deleteRow(name);
 
-      wait.until(d -> !listHasServiceAccountRow());
-      assertThat(listHasServiceAccountRow())
+      awaitNoRow(name);
+      assertThat(hasRow(name))
         .as("service account row still present after delete")
         .isFalse();
     }
@@ -171,32 +117,25 @@ public class ServiceAccountIT {
   @DisplayName("when editing and saving the YAML")
   class EditAndSave {
 
+    private String name;
+
     @BeforeEach
     void navigate() {
-      driver.navigate().to(url.toString() + "serviceaccounts/" + seededUid() + "/edit");
-      wait.until(d -> aceValue((JavascriptExecutor) d).contains("before-edit"));
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
     }
 
     @Test
     @DisplayName("saving the edited YAML persists the change to the backend")
     void savePersistsChange() {
-      ((JavascriptExecutor) driver).executeScript(
-        "const ed = document.querySelector('.ace_editor').env.editor;"
-          + "ed.setValue(ed.getValue().replace('before-edit', 'after-edit'), 1);");
+      editorReplace("before-edit", "after-edit");
+      save();
 
-      driver.findElement(By.cssSelector("[data-testid='resource-edit__save']")).click();
-
-      wait.until(d -> "after-edit".equals(backendMarker()));
-      assertThat(backendMarker())
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted service account")
         .isEqualTo("after-edit");
-    }
-
-    private String aceValue(JavascriptExecutor js) {
-      final Object value = js.executeScript(
-        "const e = document.querySelector('.ace_editor');"
-          + "return e && e.env && e.env.editor ? e.env.editor.getValue() : '';");
-      return value == null ? "" : value.toString();
     }
   }
 }


### PR DESCRIPTION
## What

The per-resource Selenium ITs repeated a large, near-identical scaffold in
every file — the `wait`/`driver` setup, the `@BeforeEach`/`@AfterEach`
(new tab + seed + cleanup + tab close), the helper quartet (`aceValue`,
`backendMarker`, `seededUid`, `listHas<X>Row`), and the boilerplate
`@Nested` groups (list/detail, delete, edit-save). #207 alone copied this ~16×.

This extracts the invariant scaffold so each IT declares only what is
resource-specific, while keeping its full spec visible in-file.

## How

- **`AbstractResourceIT<T>`** (inheritance) — owns the injected
  `WebDriver`/`KubernetesServer`/URL, the per-test isolated browser tab, the
  tuned `FluentWait`, and scope-agnostic backend helpers (`seed`/`seededUid`/
  `label` via fabric8's `client.resource(obj)`, which serves namespaced and
  cluster-scoped types alike). It declares **no** `@Nested`/`@Test`, so every
  test stays visible in the subclass.
- **`ResourceUi`** (composition) — the WebDriver plumbing (tab lifecycle,
  navigation, `data-testid` list/detail/editor queries), reusable by tests
  that can't extend the base.
- **`RbacDiscovery`** / **`OpenShiftDiscovery`** — encapsulate the discovery
  expectations the cluster-scoped RBAC and OpenShift watchers require.
- Each `@Nested` group seeds a distinctly-named resource
  (`<route>-<random>-<suffix>`) so no two tests share backend state.

## Scope

- Migrated the 16 triad ITs (ConfigMap, Service, Secret, Job, Ingress,
  HorizontalPodAutoscaler, PersistentVolumeClaim, PersistentVolume,
  ServiceAccount, Role, RoleBinding, Endpoint, Namespace, ClusterRole,
  ClusterRoleBinding, ReplicationController).
- Migrated the outliers: `DeploymentIT` and `CronJobMutationIT` (extend the
  base, bespoke groups inline), `OpenShiftIT` (extends + `OpenShiftDiscovery`),
  and `ClusterScopedResourceIT` (reuses `ResourceUi` by composition — two
  resource types in one class).
- `HomeIT`, `PodExecIT`, `PodLogsIT` stay standalone (they don't follow the
  resource list/detail/edit shape).
- No-edit resources (`Endpoint`, `Namespace`) simply omit the edit-save group.
- Documented the scaffold in `AGENTS.md` (surfaced as `CLAUDE.md`).

## Guarantees preserved

Black-box only (no app-internal mocks), one assertion per test, `data-testid`
selectors, per-test browser-tab isolation, watch-sync gating, profile
isolation, and the single-boot-per-class model.

## Verification

- `make test-it` → 102 ITs, 0 failures.
- `make license-check` → all 438 source files carry the required header.
- Net −646 lines across 25 files while adding the reusable scaffold.

Closes #209