### PR TITLE
fix(endpoints): render subset address that has no targetRef

### DIFF
--- a/src/main/frontend/src/endpoints/EndpointsDetailPage.jsx
+++ b/src/main/frontend/src/endpoints/EndpointsDetailPage.jsx
@@ -34,6 +34,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
 });
 
 const Target = ({targetRef}) => {
+  if (!targetRef) {
+    return null;
+  }
   const Component = Link[targetRef.kind] ?? Fragment;
   return (
     <Component to={`/${targetRef.kind.toLowerCase()}s/${targetRef.uid}`}>

--- a/src/test/java/com/marcnuri/yakd/endpoints/EndpointIT.java
+++ b/src/test/java/com/marcnuri/yakd/endpoints/EndpointIT.java
@@ -22,10 +22,13 @@ import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsBuilder;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EndpointIT extends AbstractResourceIT<Endpoints> {
 
   private static final String ADDRESS_IP = "10.40.50.60";
+  private static final String NO_TARGET_REF_IP = "10.40.50.61";
 
   public EndpointIT() {
     super("endpoints");
@@ -50,8 +54,8 @@ public class EndpointIT extends AbstractResourceIT<Endpoints> {
       .addNewSubset()
         .addNewAddress()
           .withIp(ADDRESS_IP)
-          // The detail page's Target component dereferences address.targetRef.kind without a
-          // null guard, so the address must carry a targetRef or the detail render would throw.
+          // Carries a targetRef so the detail page's Target component renders the resource link;
+          // the absent-targetRef path is covered by the NoTargetRef group below (see #208).
           .withNewTargetRef()
             .withKind("Pod").withName("it-target-pod").withUid("it-target-pod-uid")
           .endTargetRef()
@@ -121,6 +125,52 @@ public class EndpointIT extends AbstractResourceIT<Endpoints> {
       assertThat(hasRow(name))
         .as("endpoint row still present after delete")
         .isFalse();
+    }
+  }
+
+  // Regression coverage for #208: a subset address is not required to carry a targetRef (it is
+  // absent for manually-managed Endpoints, addresses not backed by a Pod, and notReadyAddresses).
+  // The detail page's Target component must render such an address instead of crashing. This
+  // resource shape differs from resource(String), so it is seeded directly and cleaned up here
+  // rather than through the base seed()/AfterEach (which only tracks the resource(String) shape).
+  @Nested
+  @DisplayName("when a subset address has no targetRef")
+  class NoTargetRef {
+
+    private Endpoints endpoint;
+
+    @BeforeEach
+    void seedResource() {
+      endpoint = new EndpointsBuilder()
+        .withNewMetadata()
+          .withName("endpoints-no-target-ref-" + UUID.randomUUID().toString().substring(0, 8))
+          .withNamespace("default")
+        .endMetadata()
+        .addNewSubset()
+          .addNewAddress().withIp(NO_TARGET_REF_IP).endAddress()
+          .addNewPort().withName("http").withPort(8080).withProtocol("TCP").endPort()
+        .endSubset()
+        .build();
+      kubernetes.getClient().resource(endpoint).create();
+    }
+
+    @AfterEach
+    void deleteResource() {
+      kubernetes.getClient().resource(endpoint).delete();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the address instead of crashing")
+    void detailRendersAddressWithoutTargetRef() {
+      final String uid = kubernetes.getClient().resource(endpoint).get().getMetadata().getUid();
+      openDetail(uid);
+
+      // The IP can only come from the seeded subset address, so its presence proves the detail
+      // page rendered the address even though it has no targetRef (before the fix the render threw).
+      awaitPageContains(NO_TARGET_REF_IP);
+      assertThat(pageContains(NO_TARGET_REF_IP))
+        .as("endpoint detail page renders the address that has no targetRef")
+        .isTrue();
     }
   }
 }


### PR DESCRIPTION
## Summary

The Endpoints detail page crashed when a subset address had no `targetRef`. The `Target` component dereferenced `targetRef.kind` without a null guard, and a subset address is not required to carry a `targetRef` (manually-managed Endpoints, addresses not backed by a Pod, entries under `notReadyAddresses`). Any such address threw during render, taking down the entire detail page.

## Changes

- **`endpoints/EndpointsDetailPage.jsx`** — `Target` now early-returns `null` when `targetRef` is absent, rendering an empty Target cell instead of crashing.
- **`EndpointIT.java`** — adds a `NoTargetRef` regression group that seeds an Endpoints address with no `targetRef` and asserts the detail page renders it; updates the now-stale workaround comment on the default builder.

## Testing

- Reproduced the crash with the new IT (red), then confirmed the fix (green): `make test-it IT=EndpointIT` → `Tests run: 4, Failures: 0, Errors: 0`.
- `make fmt-check`, `make typecheck`, `make lint`, `make test-frontend` (165 passed) — all green.

Closes #208