### PR TITLE
test: extend Selenium IT coverage to remaining resource types

### DIFF
--- a/src/main/frontend/src/cronjobs/CronJobsDetailPage.jsx
+++ b/src/main/frontend/src/cronjobs/CronJobsDetailPage.jsx
@@ -71,6 +71,7 @@ export const CronJobsDetailPage = withParams(
       deleteFunction={api.deleteCj}
       actions={
         <Link
+          data-testid='cronjob-detail__trigger'
           className='ml-2'
           size={Link.sizes.small}
           variant={Link.variants.outline}

--- a/src/main/frontend/src/daemonsets/List.jsx
+++ b/src/main/frontend/src/daemonsets/List.jsx
@@ -64,6 +64,7 @@ const Rows = ({daemonSets}) => {
       </Table.Cell>
       <Table.Cell className='whitespace-nowrap text-center'>
         <Link
+          data-testid='daemonset-list__restart'
           variant={Link.variants.outline}
           onClick={restart(daemonSet)}
           title='Restart'

--- a/src/main/frontend/src/deploymentconfigs/List.jsx
+++ b/src/main/frontend/src/deploymentconfigs/List.jsx
@@ -75,6 +75,7 @@ const Rows = ({deploymentConfigs}) => {
         </Table.Cell>
         <Table.Cell className='whitespace-nowrap text-center'>
           <Link
+            data-testid='deploymentconfig-list__restart'
             variant={Link.variants.outline}
             onClick={restartDC(deploymentConfig)}
             title='Restart'

--- a/src/main/frontend/src/statefulsets/List.jsx
+++ b/src/main/frontend/src/statefulsets/List.jsx
@@ -68,6 +68,7 @@ const Rows = ({statefulSets}) => {
       </Table.Cell>
       <Table.Cell className='whitespace-nowrap text-center'>
         <Link
+          data-testid='statefulset-list__restart'
           variant={Link.variants.outline}
           onClick={restartStatefulSet(statefulSet)}
           title='Restart'

--- a/src/test/java/com/marcnuri/yakd/OpenShiftIT.java
+++ b/src/test/java/com/marcnuri/yakd/OpenShiftIT.java
@@ -53,6 +53,7 @@ public class OpenShiftIT extends AbstractResourceIT<Route> {
       .withNewMetadata()
         .withName(name)
         .withNamespace("default")
+        .addToLabels("mutation-marker", "before-edit")
       .endMetadata()
       .withNewSpec()
         .withHost(ROUTE_HOST)
@@ -134,6 +135,97 @@ public class OpenShiftIT extends AbstractResourceIT<Route> {
       assertThat(pageContains(ROUTE_HOST))
         .as("route detail page contents")
         .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting a route from the list page")
+  class RouteDeleteFromList {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the route's row from the list")
+    void deleteRemovesRow() {
+      deleteRow(name);
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("route row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving a route's YAML")
+  class RouteEditAndSave {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      editorReplace("before-edit", "after-edit");
+      save();
+
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
+        .as("mutation-marker label on the persisted route")
+        .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when the server pushes live route watch events")
+  class RouteWatchLiveUpdates {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-watch");
+      openList();
+      // Waiting for the seeded row guarantees the watch stream is connected and its initial sync
+      // has replayed before the test mutates the cluster, so any later change can only reach the
+      // list through a live watch event.
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("a route created server-side appears in the list without a refresh")
+    void createdRouteAppears() {
+      final String added = seed("watch-added");
+
+      awaitRow(added);
+      assertThat(hasRow(added))
+        .as("row for the server-side-created route present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("a route deleted server-side disappears from the list without a refresh")
+    void deletedRouteDisappears() {
+      kubernetes.getClient().resources(Route.class)
+        .inNamespace("default").withName(name).delete();
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("row for the server-side-deleted route still present in the list")
+        .isFalse();
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/cronjobs/CronJobIT.java
+++ b/src/test/java/com/marcnuri/yakd/cronjobs/CronJobIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.cronjobs;
+
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.batch.v1.CronJob;
+import io.fabric8.kubernetes.api.model.batch.v1.CronJobBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("CronJob")
+public class CronJobIT extends AbstractResourceIT<CronJob> {
+
+  private static final String SEEDED_SCHEDULE = "*/1 * * * *";
+  private static final String MODIFIED_SCHEDULE = "*/5 * * * *";
+
+  public CronJobIT() {
+    super("cronjobs");
+  }
+
+  @Override
+  protected CronJob resource(String name) {
+    return new CronJobBuilder()
+      .withNewMetadata()
+        .withName(name)
+        .withNamespace("default")
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewSpec()
+        .withSchedule(SEEDED_SCHEDULE)
+        .withSuspend(false)
+        .withNewJobTemplate()
+          .withNewSpec()
+            .withNewTemplate()
+              .withNewSpec()
+                .addNewContainer().withName("container-1").withImage("busybox").endContainer()
+                .withRestartPolicy("OnFailure")
+              .endSpec()
+            .endTemplate()
+          .endSpec()
+        .endJobTemplate()
+      .endSpec()
+      .build();
+  }
+
+  private boolean triggeredJobExists(String name) {
+    return kubernetes.getClient().batch().v1().jobs().inNamespace("default").list().getItems().stream()
+      .anyMatch(job -> job.getMetadata().getName().startsWith(name + "-manual-"));
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
+    @Test
+    @DisplayName("the list renders a row for the seeded cron job")
+    void listRendersSeededRow() {
+      openList();
+
+      awaitRow(name);
+      assertThat(hasRow(name))
+        .as("row for the seeded cron job present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the list row shows the seeded cron job's schedule")
+    void listRowShowsSchedule() {
+      openList();
+
+      await(() -> rowShows(name, SEEDED_SCHEDULE));
+      assertThat(rowShows(name, SEEDED_SCHEDULE))
+        .as("seeded schedule shown in the cron job's row")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the cron job's name")
+    void detailRendersName() {
+      openDetail(seededUid(name));
+
+      awaitPageContains(name);
+      assertThat(pageContains(name))
+        .as("detail page contents")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the cron job's row from the list")
+    void deleteRemovesRow() {
+      deleteRow(name);
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("cron job row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      editorReplace("before-edit", "after-edit");
+      save();
+
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
+        .as("mutation-marker label on the persisted cron job")
+        .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when manually triggering from the detail page")
+  class Trigger {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-trigger");
+      openDetail(seededUid(name));
+      // The trigger action operates on the resource once the watch has loaded it into the
+      // store; the name only renders after that, so it is a safe gate before clicking.
+      awaitPageContains(name);
+    }
+
+    @AfterEach
+    void deleteTriggeredJobs() {
+      // The manually triggered Job is created by the app, not tracked by the base seed()
+      // bookkeeping, so delete it here lest it leak into later Job/Pod list assertions.
+      kubernetes.getClient().batch().v1().jobs().inNamespace("default").list().getItems().stream()
+        .filter(job -> job.getMetadata().getName().startsWith(name + "-manual-"))
+        .forEach(job -> kubernetes.getClient().batch().v1().jobs().inNamespace("default")
+          .withName(job.getMetadata().getName()).delete());
+    }
+
+    @Test
+    @DisplayName("clicking trigger creates a manual job on the backend")
+    void triggerCreatesJob() {
+      driver.findElement(By.cssSelector("[data-testid='cronjob-detail__trigger']")).click();
+
+      await(() -> triggeredJobExists(name));
+      assertThat(triggeredJobExists(name))
+        .as("manual job created for the triggered cron job")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when the server pushes live watch events")
+  class WatchLiveUpdates {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-watch");
+      openList();
+      // Waiting for the seeded row guarantees the watch stream is connected and its initial sync
+      // has replayed before the test mutates the cluster, so any later change can only reach the
+      // list through a live watch event.
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("a cron job created server-side appears in the list without a refresh")
+    void createdCronJobAppears() {
+      final String added = seed("watch-added");
+
+      awaitRow(added);
+      assertThat(hasRow(added))
+        .as("row for the server-side-created cron job present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("a cron job deleted server-side disappears from the list without a refresh")
+    void deletedCronJobDisappears() {
+      kubernetes.getClient().batch().v1().cronjobs().inNamespace("default").withName(name).delete();
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("row for the server-side-deleted cron job still present in the list")
+        .isFalse();
+    }
+
+    @Test
+    @DisplayName("a cron job modified server-side updates its row in place without a refresh")
+    void modifiedCronJobUpdatesRow() {
+      kubernetes.getClient().batch().v1().cronjobs().inNamespace("default").withName(name)
+        .edit(cronJob -> new CronJobBuilder(cronJob)
+          .editSpec().withSchedule(MODIFIED_SCHEDULE).endSpec().build());
+
+      await(() -> rowShows(name, MODIFIED_SCHEDULE));
+      assertThat(rowShows(name, MODIFIED_SCHEDULE))
+        .as("cron job row reflects the server-side schedule change")
+        .isTrue();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/customresourcedefinitions/CustomResourceDefinitionIT.java
+++ b/src/test/java/com/marcnuri/yakd/customresourcedefinitions/CustomResourceDefinitionIT.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.customresourcedefinitions;
+
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// List/detail rendering is covered by ClusterScopedResourceIT; this exercises the remaining
+// mutation paths (delete, edit-save) and the live watch for the cluster-scoped CRD list.
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("CustomResourceDefinition")
+public class CustomResourceDefinitionIT extends AbstractResourceIT<CustomResourceDefinition> {
+
+  public CustomResourceDefinitionIT() {
+    super("customresourcedefinitions");
+  }
+
+  @Override
+  protected CustomResourceDefinition resource(String name) {
+    return new CustomResourceDefinitionBuilder()
+      .withNewMetadata()
+        .withName(name)
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewSpec()
+        .withGroup("yakd.example.com")
+        .withScope("Cluster")
+        .withNewNames().withKind("Widget").withSingular("widget").withPlural("widgets").endNames()
+        .addNewVersion().withName("v1").withServed(true).withStorage(true).endVersion()
+      .endSpec()
+      .build();
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the custom resource definition's row from the list")
+    void deleteRemovesRow() {
+      deleteRow(name);
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("custom resource definition row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      editorReplace("before-edit", "after-edit");
+      save();
+
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
+        .as("mutation-marker label on the persisted custom resource definition")
+        .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when the server pushes live watch events")
+  class WatchLiveUpdates {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-watch");
+      openList();
+      // Waiting for the seeded row guarantees the watch stream is connected and its initial sync
+      // has replayed before the test mutates the cluster, so any later change can only reach the
+      // list through a live watch event.
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("a custom resource definition created server-side appears in the list without a refresh")
+    void createdCustomResourceDefinitionAppears() {
+      final String added = seed("watch-added");
+
+      awaitRow(added);
+      assertThat(hasRow(added))
+        .as("row for the server-side-created custom resource definition present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("a custom resource definition deleted server-side disappears from the list without a refresh")
+    void deletedCustomResourceDefinitionDisappears() {
+      kubernetes.getClient().apiextensions().v1().customResourceDefinitions().withName(name).delete();
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("row for the server-side-deleted custom resource definition still present in the list")
+        .isFalse();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/customresources/CustomResourceIT.java
+++ b/src/test/java/com/marcnuri/yakd/customresources/CustomResourceIT.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.customresources;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import com.marcnuri.yakd.selenium.ResourceUi;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import java.net.URL;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// A namespaced custom resource instance: its list is embedded (fetched on demand, not watched) in
+// the owning CRD's detail page, and editing opens the shared ResourceEditModal. Cluster-scoped
+// instance listing is covered by ClusterScopedResourceIT; this exercises the namespaced scope plus
+// the instance delete and edit-save mutation paths. Driven via ResourceUi by composition.
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("CustomResource (namespaced)")
+public class CustomResourceIT {
+
+  private static final String GROUP = "yakd.example.com";
+  private static final String VERSION = "v1";
+  private static final String PLURAL = "gadgets";
+  private static final String KIND = "Gadget";
+  private static final String CRD_NAME = PLURAL + "." + GROUP;
+  private static final String NAMESPACE = "default";
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  ResourceUi ui;
+
+  private final String instanceName = "gadget-" + UUID.randomUUID().toString().substring(0, 8);
+  private String crdUid;
+
+  @BeforeEach
+  void setUp() {
+    ui = ResourceUi.openTab(driver, url);
+    kubernetes.getClient().resource(customResourceDefinition()).createOr(NonDeletingOperation::update);
+    crdUid = kubernetes.getClient().apiextensions().v1().customResourceDefinitions()
+      .withName(CRD_NAME).get().getMetadata().getUid();
+    kubernetes.getClient().genericKubernetesResources(namespacedContext())
+      .inNamespace(NAMESPACE).resource(instance()).createOr(NonDeletingOperation::update);
+    // The CRD detail page hosts the (on-demand) custom resource list; wait for the instance row so
+    // every test starts from a page that has fetched the namespaced instance through the backend.
+    ui.openDetail("customresourcedefinitions", crdUid);
+    ui.await(() -> ui.hasRow(instanceName));
+  }
+
+  @AfterEach
+  void cleanUp() {
+    try {
+      kubernetes.getClient().genericKubernetesResources(namespacedContext())
+        .inNamespace(NAMESPACE).withName(instanceName).delete();
+      kubernetes.getClient().apiextensions().v1().customResourceDefinitions().withName(CRD_NAME).delete();
+    } finally {
+      ui.closeTab();
+    }
+  }
+
+  private static ResourceDefinitionContext namespacedContext() {
+    return new ResourceDefinitionContext.Builder()
+      .withNamespaced(true).withGroup(GROUP).withVersion(VERSION).withPlural(PLURAL).build();
+  }
+
+  private static CustomResourceDefinition customResourceDefinition() {
+    return new CustomResourceDefinitionBuilder()
+      .withNewMetadata().withName(CRD_NAME).endMetadata()
+      .withNewSpec()
+        .withGroup(GROUP)
+        .withScope("Namespaced")
+        .withNewNames().withKind(KIND).withSingular("gadget").withPlural(PLURAL).endNames()
+        .addNewVersion().withName(VERSION).withServed(true).withStorage(true).endVersion()
+      .endSpec()
+      .build();
+  }
+
+  private GenericKubernetesResource instance() {
+    return new GenericKubernetesResourceBuilder()
+      .withApiVersion(GROUP + "/" + VERSION)
+      .withKind(KIND)
+      .withNewMetadata()
+        .withName(instanceName)
+        .withNamespace(NAMESPACE)
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .build();
+  }
+
+  private GenericKubernetesResource backendInstance() {
+    return kubernetes.getClient().genericKubernetesResources(namespacedContext())
+      .inNamespace(NAMESPACE).withName(instanceName).get();
+  }
+
+  private String backendMutationMarker() {
+    final GenericKubernetesResource stored = backendInstance();
+    if (stored == null || stored.getMetadata().getLabels() == null) {
+      return null;
+    }
+    return stored.getMetadata().getLabels().get("mutation-marker");
+  }
+
+  @Nested
+  @DisplayName("when viewing the owning CRD's detail page")
+  class ListAndMutate {
+
+    @Test
+    @DisplayName("the detail page lists the seeded namespaced custom resource instance")
+    void listRendersNamespacedInstance() {
+      assertThat(ui.hasRow(instanceName))
+        .as("row for the seeded namespaced custom resource instance present in the detail page")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the custom resource instance from the backend")
+    void deleteRemovesInstance() {
+      ui.deleteRow(instanceName);
+
+      ui.await(() -> backendInstance() == null);
+      assertThat(backendInstance())
+        .as("custom resource instance still present in the backend after delete")
+        .isNull();
+    }
+
+    @Test
+    @DisplayName("editing and saving persists the change to the backend instance")
+    void editPersistsChange() {
+      // The instance name renders as a link that opens the edit modal for that instance.
+      driver.findElement(By.linkText(instanceName)).click();
+      ui.await(() -> ui.editorContains("before-edit"));
+
+      ui.editorReplace("before-edit", "after-edit");
+      ui.save();
+
+      ui.await(() -> "after-edit".equals(backendMutationMarker()));
+      assertThat(backendMutationMarker())
+        .as("mutation-marker label on the persisted custom resource instance")
+        .isEqualTo("after-edit");
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/daemonsets/DaemonSetIT.java
+++ b/src/test/java/com/marcnuri/yakd/daemonsets/DaemonSetIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.daemonsets;
+
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.apps.DaemonSet;
+import io.fabric8.kubernetes.api.model.apps.DaemonSetBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("DaemonSet")
+public class DaemonSetIT extends AbstractResourceIT<DaemonSet> {
+
+  private static final String SEEDED_IMAGE = "busybox";
+
+  public DaemonSetIT() {
+    super("daemonsets");
+  }
+
+  @Override
+  protected DaemonSet resource(String name) {
+    return new DaemonSetBuilder()
+      .withNewMetadata()
+        .withName(name)
+        .withNamespace("default")
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewSpec()
+        .withNewSelector().addToMatchLabels("app", name).endSelector()
+        .withNewTemplate()
+          .withNewMetadata().addToLabels("app", name).endMetadata()
+          .withNewSpec()
+            .addNewContainer().withName("container-1").withImage(SEEDED_IMAGE).endContainer()
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .build();
+  }
+
+  private String backendRestartedAt(String name) {
+    final DaemonSet daemonSet = kubernetes.getClient().apps().daemonSets()
+      .inNamespace("default").withName(name).get();
+    if (daemonSet == null || daemonSet.getSpec() == null
+      || daemonSet.getSpec().getTemplate() == null
+      || daemonSet.getSpec().getTemplate().getMetadata() == null
+      || daemonSet.getSpec().getTemplate().getMetadata().getAnnotations() == null) {
+      return null;
+    }
+    return daemonSet.getSpec().getTemplate().getMetadata().getAnnotations()
+      .get("yakd.marcnuri.com/restartedAt");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
+    @Test
+    @DisplayName("the list renders a row for the seeded daemon set")
+    void listRendersSeededRow() {
+      openList();
+
+      awaitRow(name);
+      assertThat(hasRow(name))
+        .as("row for the seeded daemon set present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the list row shows the seeded daemon set's container image")
+    void listRowShowsImage() {
+      openList();
+
+      await(() -> rowShows(name, SEEDED_IMAGE));
+      assertThat(rowShows(name, SEEDED_IMAGE))
+        .as("seeded container image shown in the daemon set's row")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the daemon set's name")
+    void detailRendersName() {
+      openDetail(seededUid(name));
+
+      awaitPageContains(name);
+      assertThat(pageContains(name))
+        .as("detail page contents")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the daemon set's row from the list")
+    void deleteRemovesRow() {
+      deleteRow(name);
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("daemon set row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      editorReplace("before-edit", "after-edit");
+      save();
+
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
+        .as("mutation-marker label on the persisted daemon set")
+        .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when restarting from the list page")
+  class Restart {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-restart");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking restart records a rollout restart on the backend")
+    void restartRecordsRestartedAt() {
+      driver.findElement(By.cssSelector("[data-testid='daemonset-list__restart']")).click();
+
+      await(() -> backendRestartedAt(name) != null);
+      assertThat(backendRestartedAt(name))
+        .as("yakd.marcnuri.com/restartedAt annotation on the persisted daemon set")
+        .isNotNull();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/deploymentconfigs/DeploymentConfigIT.java
+++ b/src/test/java/com/marcnuri/yakd/deploymentconfigs/DeploymentConfigIT.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.deploymentconfigs;
+
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.OpenShiftDiscovery;
+import com.marcnuri.yakd.selenium.OpenShiftIntegrationTestProfile;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(OpenShiftIntegrationTestProfile.class)
+@DisplayName("DeploymentConfig")
+public class DeploymentConfigIT extends AbstractResourceIT<DeploymentConfig> {
+
+  private static final String SEEDED_IMAGE = "busybox";
+
+  public DeploymentConfigIT() {
+    super("deploymentconfigs");
+  }
+
+  @BeforeEach
+  void advertiseOpenShiftDiscovery() {
+    OpenShiftDiscovery.advertise(kubernetes);
+  }
+
+  @Override
+  protected DeploymentConfig resource(String name) {
+    return new DeploymentConfigBuilder()
+      .withNewMetadata()
+        .withName(name)
+        .withNamespace("default")
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewSpec()
+        .withReplicas(1)
+        .addToSelector("app", name)
+        .withNewTemplate()
+          .withNewMetadata().addToLabels("app", name).endMetadata()
+          .withNewSpec()
+            .addNewContainer().withName("container-1").withImage(SEEDED_IMAGE).endContainer()
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .build();
+  }
+
+  private Integer backendReplicas(String name) {
+    final DeploymentConfig deploymentConfig = kubernetes.getClient().resources(DeploymentConfig.class)
+      .inNamespace("default").withName(name).get();
+    if (deploymentConfig == null || deploymentConfig.getSpec() == null) {
+      return null;
+    }
+    return deploymentConfig.getSpec().getReplicas();
+  }
+
+  private String backendRestartedAt(String name) {
+    final DeploymentConfig deploymentConfig = kubernetes.getClient().resources(DeploymentConfig.class)
+      .inNamespace("default").withName(name).get();
+    if (deploymentConfig == null || deploymentConfig.getSpec() == null
+      || deploymentConfig.getSpec().getTemplate() == null
+      || deploymentConfig.getSpec().getTemplate().getMetadata() == null
+      || deploymentConfig.getSpec().getTemplate().getMetadata().getAnnotations() == null) {
+      return null;
+    }
+    return deploymentConfig.getSpec().getTemplate().getMetadata().getAnnotations()
+      .get("yakd.marcnuri.com/restartedAt");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
+    @Test
+    @DisplayName("the list renders a row for the seeded deployment config")
+    void listRendersSeededRow() {
+      openList();
+
+      awaitRow(name);
+      assertThat(hasRow(name))
+        .as("row for the seeded deployment config present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the list row shows the seeded deployment config's container image")
+    void listRowShowsImage() {
+      openList();
+
+      await(() -> rowShows(name, SEEDED_IMAGE));
+      assertThat(rowShows(name, SEEDED_IMAGE))
+        .as("seeded container image shown in the deployment config's row")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the deployment config's name")
+    void detailRendersName() {
+      openDetail(seededUid(name));
+
+      awaitPageContains(name);
+      assertThat(pageContains(name))
+        .as("detail page contents")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the deployment config's row from the list")
+    void deleteRemovesRow() {
+      deleteRow(name);
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("deployment config row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      editorReplace("before-edit", "after-edit");
+      save();
+
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
+        .as("mutation-marker label on the persisted deployment config")
+        .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when scaling from the detail page")
+  class Scale {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-scale");
+      openDetail(seededUid(name));
+      // The replicas control operates on the resource once the watch has loaded it
+      // into the store; the name only renders after that, so it is a safe gate.
+      awaitPageContains(name);
+    }
+
+    @Test
+    @DisplayName("incrementing the replicas persists the new replica count to the backend")
+    void incrementPersistsReplicas() {
+      driver.findElement(By.cssSelector("[data-testid='replicas-field__increment']")).click();
+
+      await(() -> Integer.valueOf(2).equals(backendReplicas(name)));
+      assertThat(backendReplicas(name))
+        .as("spec.replicas on the persisted deployment config")
+        .isEqualTo(2);
+    }
+  }
+
+  @Nested
+  @DisplayName("when restarting from the list page")
+  class Restart {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-restart");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking restart records a rollout restart on the backend")
+    void restartRecordsRestartedAt() {
+      driver.findElement(By.cssSelector("[data-testid='deploymentconfig-list__restart']")).click();
+
+      await(() -> backendRestartedAt(name) != null);
+      assertThat(backendRestartedAt(name))
+        .as("yakd.marcnuri.com/restartedAt annotation on the persisted deployment config")
+        .isNotNull();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/node/NodeIT.java
+++ b/src/test/java/com/marcnuri/yakd/node/NodeIT.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.node;
+
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Node detail/list pages are name-keyed; this exercises edit-save, watch and the detail dials.
+// List/detail rendering is already covered by ClusterScopedResourceIT.
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Node")
+public class NodeIT extends AbstractResourceIT<Node> {
+
+  public NodeIT() {
+    super("nodes");
+  }
+
+  @Override
+  protected Node resource(String name) {
+    return new NodeBuilder()
+      .withNewMetadata()
+        .withName(name)
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewStatus()
+        .addToAllocatable("cpu", new Quantity("8"))
+        .addToAllocatable("memory", new Quantity("16384Mi"))
+        .addToAllocatable("pods", new Quantity("110"))
+        .addNewCondition().withType("Ready").withStatus("True").endCondition()
+        .withNewNodeInfo()
+          .withOperatingSystem("linux")
+          .withArchitecture("arm64")
+          .withKernelVersion("6.6.0")
+          .withContainerRuntimeVersion("containerd://1.7.0")
+          .withKubeletVersion("v1.33.0-node-it")
+        .endNodeInfo()
+      .endStatus()
+      .build();
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-edit");
+      // The editor route is uid-keyed (state.nodes[uid]), unlike the name-keyed detail page.
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      editorReplace("before-edit", "after-edit");
+      save();
+
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
+        .as("mutation-marker label on the persisted node")
+        .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when the server pushes live watch events")
+  class WatchLiveUpdates {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-watch");
+      openList();
+      // Waiting for the seeded row guarantees the watch stream is connected and its initial sync
+      // has replayed before the test mutates the cluster, so any later change can only reach the
+      // list through a live watch event.
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("a node created server-side appears in the list without a refresh")
+    void createdNodeAppears() {
+      final String added = seed("watch-added");
+
+      awaitRow(added);
+      assertThat(hasRow(added))
+        .as("row for the server-side-created node present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("a node deleted server-side disappears from the list without a refresh")
+    void deletedNodeDisappears() {
+      kubernetes.getClient().nodes().withName(name).delete();
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("row for the server-side-deleted node still present in the list")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when viewing the resource dials on the detail page")
+  class Dials {
+
+    private String name;
+    private String podName;
+
+    @BeforeEach
+    void seedNodeAndScheduledPod() {
+      name = seed("to-measure");
+      podName = name + "-pod";
+      // A pod scheduled on the node carrying resource requests: the CPU/Memory dials sum these
+      // requests against the node's allocatable capacity.
+      kubernetes.getClient().pods().inNamespace("default").resource(new PodBuilder()
+        .withNewMetadata().withName(podName).withNamespace("default").endMetadata()
+        .withNewSpec()
+          .withNodeName(name)
+          .addNewContainer()
+            .withName("container-1").withImage("busybox")
+            .withNewResources()
+              .addToRequests("cpu", new Quantity("250m"))
+              .addToRequests("memory", new Quantity("321Mi"))
+            .endResources()
+          .endContainer()
+        .endSpec()
+        .build()).createOr(NonDeletingOperation::update);
+      open("nodes/" + name);
+      // The node name renders once the detail page has loaded the node from the watch, so it is a
+      // safe gate before trusting the computed dials.
+      awaitPageContains(name);
+    }
+
+    @AfterEach
+    void deletePod() {
+      kubernetes.getClient().pods().inNamespace("default").withName(podName).delete();
+    }
+
+    @Test
+    @DisplayName("the CPU dial renders the summed requested CPU from scheduled pods")
+    void cpuDialShowsRequested() {
+      // 250m requested by the scheduled pod, formatted to three decimals by the UI.
+      awaitPageContains("0.250");
+      assertThat(pageContains("0.250"))
+        .as("requested CPU rendered in the node's CPU dial")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the Memory dial renders the node's allocatable memory")
+    void memoryDialShowsAllocatable() {
+      // 16384Mi allocatable on the node, rendered human-readable by the UI.
+      awaitPageContains("16.000 GiB");
+      assertThat(pageContains("16.000 GiB"))
+        .as("allocatable memory rendered in the node's Memory dial")
+        .isTrue();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/pod/PodIT.java
+++ b/src/test/java/com/marcnuri/yakd/pod/PodIT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.pod;
+
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("Pod")
+public class PodIT extends AbstractResourceIT<Pod> {
+
+  private static final String SEEDED_PHASE = "Running";
+  private static final String MODIFIED_PHASE = "Succeeded";
+
+  public PodIT() {
+    super("pods");
+  }
+
+  @Override
+  protected Pod resource(String name) {
+    return new PodBuilder()
+      .withNewMetadata()
+        .withName(name)
+        .withNamespace("default")
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewSpec()
+        .addNewContainer().withName("container-1").withImage("busybox").endContainer()
+      .endSpec()
+      .withNewStatus().withPhase(SEEDED_PHASE).endStatus()
+      .build();
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
+    @Test
+    @DisplayName("the list renders a row for the seeded pod")
+    void listRendersSeededRow() {
+      openList();
+
+      awaitRow(name);
+      assertThat(hasRow(name))
+        .as("row for the seeded pod present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the list row shows the seeded pod's phase")
+    void listRowShowsPhase() {
+      openList();
+
+      await(() -> rowShows(name, SEEDED_PHASE));
+      assertThat(rowShows(name, SEEDED_PHASE))
+        .as("seeded phase shown in the pod's row")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the pod's name")
+    void detailRendersName() {
+      openDetail(seededUid(name));
+
+      awaitPageContains(name);
+      assertThat(pageContains(name))
+        .as("detail page contents")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the pod's row from the list")
+    void deleteRemovesRow() {
+      deleteRow(name);
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("pod row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      editorReplace("before-edit", "after-edit");
+      save();
+
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
+        .as("mutation-marker label on the persisted pod")
+        .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when viewing metrics on the detail page")
+  class Metrics {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-measure");
+      // The detail page polls /pods/<ns>/<name>/metrics, which the backend proxies to the
+      // metrics.k8s.io API; seed a PodMetrics there so the page can render the usage.
+      kubernetes.expect().get()
+        .withPath("/apis/metrics.k8s.io/v1beta1/namespaces/default/pods/" + name)
+        .andReturn(200, new PodMetricsBuilder()
+          .withNewMetadata().withName(name).withNamespace("default").endMetadata()
+          .addNewContainer()
+            .withName("container-1")
+            .addToUsage("cpu", new Quantity("123m"))
+            .addToUsage("memory", new Quantity("321Mi"))
+          .endContainer()
+          .build())
+        .always();
+      openDetail(seededUid(name));
+      awaitPageContains(name);
+    }
+
+    @Test
+    @DisplayName("the detail page renders the summed container CPU usage")
+    void rendersUsedCpu() {
+      // 123m summed and formatted to three decimals by the UI.
+      awaitPageContains("0.123");
+      assertThat(pageContains("0.123"))
+        .as("used CPU rendered from the seeded pod metrics")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the summed container memory usage")
+    void rendersUsedMemory() {
+      // 321Mi rendered human-readable by the UI.
+      awaitPageContains("321 MiB");
+      assertThat(pageContains("321 MiB"))
+        .as("used memory rendered from the seeded pod metrics")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when the server pushes live watch events")
+  class WatchLiveUpdates {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-watch");
+      openList();
+      // Waiting for the seeded row guarantees the watch stream is connected and its initial sync
+      // has replayed before the test mutates the cluster, so any later change can only reach the
+      // list through a live watch event.
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("a pod created server-side appears in the list without a refresh")
+    void createdPodAppears() {
+      final String added = seed("watch-added");
+
+      awaitRow(added);
+      assertThat(hasRow(added))
+        .as("row for the server-side-created pod present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("a pod deleted server-side disappears from the list without a refresh")
+    void deletedPodDisappears() {
+      kubernetes.getClient().pods().inNamespace("default").withName(name).delete();
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("row for the server-side-deleted pod still present in the list")
+        .isFalse();
+    }
+
+    @Test
+    @DisplayName("a pod modified server-side updates its row in place without a refresh")
+    void modifiedPodUpdatesRow() {
+      kubernetes.getClient().pods().inNamespace("default").withName(name)
+        .edit(pod -> new PodBuilder(pod)
+          .editStatus().withPhase(MODIFIED_PHASE).endStatus().build());
+
+      await(() -> rowShows(name, MODIFIED_PHASE));
+      assertThat(rowShows(name, MODIFIED_PHASE))
+        .as("pod row reflects the server-side phase change")
+        .isTrue();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/replicaset/ReplicaSetIT.java
+++ b/src/test/java/com/marcnuri/yakd/replicaset/ReplicaSetIT.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.replicaset;
+
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import com.marcnuri.yakd.selenium.ResourceUi;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+
+import java.net.URL;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// A ReplicaSet has no list/detail route of its own: its list is only rendered, filtered by owner
+// uid, inside the owning Deployment's detail page. So this drives that page directly via ResourceUi
+// by composition rather than extending the single-type AbstractResourceIT.
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("ReplicaSet")
+public class ReplicaSetIT {
+
+  @KubernetesTestServer
+  KubernetesServer kubernetes;
+
+  @TestHTTPResource
+  URL url;
+  WebDriver driver;
+  ResourceUi ui;
+
+  private final String suffix = UUID.randomUUID().toString().substring(0, 8);
+  private final String deploymentName = "replicaset-it-deploy-" + suffix;
+  private final String replicaSetName = "replicaset-it-rs-" + suffix;
+  private String deploymentUid;
+
+  @BeforeEach
+  void setUp() {
+    ui = ResourceUi.openTab(driver, url);
+    kubernetes.getClient().resource(deployment()).createOr(NonDeletingOperation::update);
+    deploymentUid = kubernetes.getClient().apps().deployments().inNamespace("default")
+      .withName(deploymentName).get().getMetadata().getUid();
+    kubernetes.getClient().resource(replicaSet(deploymentUid)).createOr(NonDeletingOperation::update);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    try {
+      kubernetes.getClient().apps().replicaSets().inNamespace("default").withName(replicaSetName).delete();
+      kubernetes.getClient().apps().deployments().inNamespace("default").withName(deploymentName).delete();
+    } finally {
+      ui.closeTab();
+    }
+  }
+
+  private Deployment deployment() {
+    return new DeploymentBuilder()
+      .withNewMetadata().withName(deploymentName).withNamespace("default").endMetadata()
+      .withNewSpec()
+        .withReplicas(1)
+        .withNewSelector().addToMatchLabels("app", deploymentName).endSelector()
+        .withNewTemplate()
+          .withNewMetadata().addToLabels("app", deploymentName).endMetadata()
+          .withNewSpec()
+            .addNewContainer().withName("container-1").withImage("busybox").endContainer()
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .build();
+  }
+
+  private ReplicaSet replicaSet(String ownerUid) {
+    return new ReplicaSetBuilder()
+      .withNewMetadata()
+        .withName(replicaSetName)
+        .withNamespace("default")
+        .withOwnerReferences(new OwnerReferenceBuilder()
+          .withApiVersion("apps/v1").withKind("Deployment")
+          .withName(deploymentName).withUid(ownerUid).withController(true).build())
+      .endMetadata()
+      .withNewSpec()
+        .withReplicas(1)
+        .withNewSelector().addToMatchLabels("app", deploymentName).endSelector()
+      .endSpec()
+      .build();
+  }
+
+  private ReplicaSet backendReplicaSet() {
+    return kubernetes.getClient().apps().replicaSets().inNamespace("default").withName(replicaSetName).get();
+  }
+
+  private void openOwningDeploymentDetail() {
+    ui.openDetail("deployments", deploymentUid);
+    // The replica-sets card only renders once the deployment is loaded from the watch; the
+    // deployment name renders after that, so it is a safe gate before trusting the embedded list.
+    ui.await(() -> ui.pageContains(deploymentName));
+  }
+
+  @Nested
+  @DisplayName("when viewing the owning deployment's detail page")
+  class ListAndDelete {
+
+    @Test
+    @DisplayName("the replica sets card renders a row for the owned replica set")
+    void listRendersOwnedReplicaSet() {
+      openOwningDeploymentDetail();
+
+      ui.await(() -> ui.hasRow(replicaSetName));
+      assertThat(ui.hasRow(replicaSetName))
+        .as("row for the owned replica set present in the deployment detail page")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the replica set from the backend")
+    void deleteRemovesReplicaSet() {
+      openOwningDeploymentDetail();
+      ui.await(() -> ui.hasRow(replicaSetName));
+
+      ui.deleteRow(replicaSetName);
+
+      ui.await(() -> backendReplicaSet() == null);
+      assertThat(backendReplicaSet())
+        .as("replica set still present in the backend after delete")
+        .isNull();
+    }
+  }
+}

--- a/src/test/java/com/marcnuri/yakd/statefulsets/StatefulSetIT.java
+++ b/src/test/java/com/marcnuri/yakd/statefulsets/StatefulSetIT.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.marcnuri.yakd.statefulsets;
+
+import com.marcnuri.yakd.selenium.AbstractResourceIT;
+import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayName("StatefulSet")
+public class StatefulSetIT extends AbstractResourceIT<StatefulSet> {
+
+  private static final String SEEDED_IMAGE = "busybox";
+
+  public StatefulSetIT() {
+    super("statefulsets");
+  }
+
+  @Override
+  protected StatefulSet resource(String name) {
+    return new StatefulSetBuilder()
+      .withNewMetadata()
+        .withName(name)
+        .withNamespace("default")
+        .addToLabels("mutation-marker", "before-edit")
+      .endMetadata()
+      .withNewSpec()
+        .withReplicas(1)
+        .withNewSelector().addToMatchLabels("app", name).endSelector()
+        .withNewTemplate()
+          .withNewMetadata().addToLabels("app", name).endMetadata()
+          .withNewSpec()
+            .addNewContainer().withName("container-1").withImage(SEEDED_IMAGE).endContainer()
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .build();
+  }
+
+  private Integer backendReplicas(String name) {
+    final StatefulSet statefulSet = kubernetes.getClient().apps().statefulSets()
+      .inNamespace("default").withName(name).get();
+    if (statefulSet == null || statefulSet.getSpec() == null) {
+      return null;
+    }
+    return statefulSet.getSpec().getReplicas();
+  }
+
+  private String backendRestartedAt(String name) {
+    final StatefulSet statefulSet = kubernetes.getClient().apps().statefulSets()
+      .inNamespace("default").withName(name).get();
+    if (statefulSet == null || statefulSet.getSpec() == null
+      || statefulSet.getSpec().getTemplate() == null
+      || statefulSet.getSpec().getTemplate().getMetadata() == null
+      || statefulSet.getSpec().getTemplate().getMetadata().getAnnotations() == null) {
+      return null;
+    }
+    return statefulSet.getSpec().getTemplate().getMetadata().getAnnotations()
+      .get("kubectl.kubernetes.io/restartedAt");
+  }
+
+  @Nested
+  @DisplayName("when viewing the list and detail pages")
+  class ListAndDetail {
+
+    private String name;
+
+    @BeforeEach
+    void seedResource() {
+      name = seed("to-view");
+    }
+
+    @Test
+    @DisplayName("the list renders a row for the seeded stateful set")
+    void listRendersSeededRow() {
+      openList();
+
+      awaitRow(name);
+      assertThat(hasRow(name))
+        .as("row for the seeded stateful set present in the list")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the list row shows the seeded stateful set's container image")
+    void listRowShowsImage() {
+      openList();
+
+      await(() -> rowShows(name, SEEDED_IMAGE));
+      assertThat(rowShows(name, SEEDED_IMAGE))
+        .as("seeded container image shown in the stateful set's row")
+        .isTrue();
+    }
+
+    @Test
+    @DisplayName("the detail page renders the stateful set's name")
+    void detailRendersName() {
+      openDetail(seededUid(name));
+
+      awaitPageContains(name);
+      assertThat(pageContains(name))
+        .as("detail page contents")
+        .isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the list page")
+  class DeleteFromList {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-delete");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the stateful set's row from the list")
+    void deleteRemovesRow() {
+      deleteRow(name);
+
+      awaitNoRow(name);
+      assertThat(hasRow(name))
+        .as("stateful set row still present after delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when editing and saving the YAML")
+  class EditAndSave {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-edit");
+      openEditor(seededUid(name));
+      awaitEditorContains("before-edit");
+    }
+
+    @Test
+    @DisplayName("saving the edited YAML persists the change to the backend")
+    void savePersistsChange() {
+      editorReplace("before-edit", "after-edit");
+      save();
+
+      await(() -> "after-edit".equals(label(name, "mutation-marker")));
+      assertThat(label(name, "mutation-marker"))
+        .as("mutation-marker label on the persisted stateful set")
+        .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when scaling from the detail page")
+  class Scale {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-scale");
+      openDetail(seededUid(name));
+      // The replicas control operates on the resource once the watch has loaded it
+      // into the store; the name only renders after that, so it is a safe gate.
+      awaitPageContains(name);
+    }
+
+    @Test
+    @DisplayName("incrementing the replicas persists the new replica count to the backend")
+    void incrementPersistsReplicas() {
+      driver.findElement(By.cssSelector("[data-testid='replicas-field__increment']")).click();
+
+      await(() -> Integer.valueOf(2).equals(backendReplicas(name)));
+      assertThat(backendReplicas(name))
+        .as("spec.replicas on the persisted stateful set")
+        .isEqualTo(2);
+    }
+  }
+
+  @Nested
+  @DisplayName("when restarting from the list page")
+  class Restart {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-restart");
+      openList();
+      awaitRow(name);
+    }
+
+    @Test
+    @DisplayName("clicking restart records a rollout restart on the backend")
+    void restartRecordsRestartedAt() {
+      driver.findElement(By.cssSelector("[data-testid='statefulset-list__restart']")).click();
+
+      await(() -> backendRestartedAt(name) != null);
+      assertThat(backendRestartedAt(name))
+        .as("kubectl.kubernetes.io/restartedAt annotation on the persisted stateful set")
+        .isNotNull();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Extends the Selenium IT suite (full-stack, Fabric8 MockServer, black-box) to
cover every remaining Kubernetes/OpenShift resource type and mutation path left
after #207/#210, completing the tracker in #205.

## New / extended IT classes

| Resource | IT | Behaviors |
|---|---|---|
| StatefulSet | `StatefulSetIT` | list/detail, delete, edit-save, restart, scale |
| DaemonSet | `DaemonSetIT` | list/detail, delete, edit-save, restart |
| DeploymentConfig | `DeploymentConfigIT` | list/detail, delete, edit-save, restart, scale (OpenShift) |
| Pod | `PodIT` | list/detail, delete, edit-save, watch (ADDED/MODIFIED/DELETED), metrics |
| CronJob | `CronJobIT` | list/detail, delete, edit-save, trigger, watch |
| Node | `NodeIT` | edit-save, watch, CPU/Memory detail dials |
| CustomResourceDefinition | `CustomResourceDefinitionIT` | delete, edit-save, watch |
| CustomResource | `CustomResourceIT` | namespaced instance list, delete, edit-save |
| ReplicaSet | `ReplicaSetIT` | list + delete via the owning Deployment's detail page |
| Route | `OpenShiftIT` (extended) | + delete, edit-save, watch |

Suspend/resume stays in `CronJobMutationIT`; Node/CRD/CustomResource list-and-detail
stays in `ClusterScopedResourceIT`.

## Production changes

Adds four `data-testid` hooks to restart/trigger controls that lacked them,
following the `<feature>__<element>` convention and the `deployment-list__restart`
precedent: `statefulset-list__restart`, `daemonset-list__restart`,
`deploymentconfig-list__restart`, `cronjob-detail__trigger`. These are inert (the
`Link` component already forwards `data-testid`); no behavior change.

## Testing

`make test-it` green: 160 tests, 0 failures, 0 errors. Every mutation test asserts
backend state (delete/edit/scale/restart/trigger/metrics/dials); one assertion per
test; black-box (no mocks).

Refs #205