### PR TITLE
fix(frontend): clear CI ESLint warnings

### DIFF
--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -44,7 +44,7 @@
     "ws": "8.19.0"
   },
   "scripts": {
-    "eslint": "eslint src/.",
+    "eslint": "eslint src/. --max-warnings=0",
     "prettier": "prettier 'src/**/*.{js,jsx,ts,tsx,json,css,scss,md}' --ignore-path ../../../.gitignore --write",
     "prettier:check": "prettier 'src/**/*.{js,jsx,ts,tsx,json,css,scss,md}' --ignore-path ../../../.gitignore --check",
     "typecheck": "tsc -p jsconfig.json",

--- a/src/main/frontend/src/configmaps/List.jsx
+++ b/src/main/frontend/src/configmaps/List.jsx
@@ -21,7 +21,7 @@ import {Icon, Link, ResourceListV2, Table} from '../components';
 import {api} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon className='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/cronjobs/List.jsx
+++ b/src/main/frontend/src/cronjobs/List.jsx
@@ -22,7 +22,7 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/customresourcedefinitions/List.jsx
+++ b/src/main/frontend/src/customresourcedefinitions/List.jsx
@@ -21,7 +21,7 @@ import {Icon, Link, ResourceListV2, Table} from '../components';
 import {api, selectors, GroupLink} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon className='fa-id-card' /> Name
   </span>,
   'Group',

--- a/src/main/frontend/src/customresources/List.jsx
+++ b/src/main/frontend/src/customresources/List.jsx
@@ -23,7 +23,7 @@ import {api, selectors} from './';
 
 const headers = customResourceDefinition => {
   const ret = [
-    <span>
+    <span key='name'>
       <Icon className='fa-id-card' /> Name
     </span>
   ];

--- a/src/main/frontend/src/daemonsets/List.jsx
+++ b/src/main/frontend/src/daemonsets/List.jsx
@@ -22,11 +22,11 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',
-  <span>
+  <span key='images'>
     <Icon icon='fa-layer-group' /> Images
   </span>,
   ''

--- a/src/main/frontend/src/deploymentconfigs/List.jsx
+++ b/src/main/frontend/src/deploymentconfigs/List.jsx
@@ -22,11 +22,11 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',
-  <span>
+  <span key='images'>
     <Icon icon='fa-layer-group' /> Images
   </span>,
   ''

--- a/src/main/frontend/src/deployments/List.jsx
+++ b/src/main/frontend/src/deployments/List.jsx
@@ -22,11 +22,11 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',
-  <span>
+  <span key='images'>
     <Icon icon='fa-layer-group' /> Images
   </span>,
   ''

--- a/src/main/frontend/src/endpoints/List.jsx
+++ b/src/main/frontend/src/endpoints/List.jsx
@@ -27,7 +27,7 @@ import {Age, Icon, Link, ResourceListV2, Table} from '../components';
 import {api, selectors} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon className='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/events/List.jsx
+++ b/src/main/frontend/src/events/List.jsx
@@ -23,12 +23,12 @@ import {selectors} from './';
 const headers = [
   '',
   'Type',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Reason',
   'Event',
-  <div className='text-right'>
+  <div key='last-seen' className='text-right'>
     <Icon stylePrefix='far' icon='fa-clock' /> Last Seen
   </div>
 ];

--- a/src/main/frontend/src/horizontalpodautoscalers/List.jsx
+++ b/src/main/frontend/src/horizontalpodautoscalers/List.jsx
@@ -22,11 +22,11 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',
-  <span>Scale Target</span>,
+  <span key='scale-target'>Scale Target</span>,
   ''
 ];
 

--- a/src/main/frontend/src/ingresses/List.jsx
+++ b/src/main/frontend/src/ingresses/List.jsx
@@ -21,7 +21,7 @@ import {Icon, Link, ResourceListV2, Table} from '../components';
 import {api, selectors} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/jobs/List.jsx
+++ b/src/main/frontend/src/jobs/List.jsx
@@ -22,7 +22,7 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/namespaces/List.jsx
+++ b/src/main/frontend/src/namespaces/List.jsx
@@ -28,11 +28,11 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Phase',
-  <span>
+  <span key='labels'>
     <Icon icon='fa-tags' /> Labels
   </span>,
   ''

--- a/src/main/frontend/src/nodes/List.jsx
+++ b/src/main/frontend/src/nodes/List.jsx
@@ -28,13 +28,13 @@ import {selectors} from './';
 
 const headers = [
   '',
-  <span className='whitespace-nowrap'>
+  <span key='name' className='whitespace-nowrap'>
     <Icon icon='fa-id-card' /> Name
   </span>,
-  <span className='whitespace-nowrap'>
+  <span key='roles' className='whitespace-nowrap'>
     <Icon icon='fa-server' /> Roles
   </span>,
-  <span>
+  <span key='labels'>
     <Icon icon='fa-tags' /> Labels
   </span>
 ];

--- a/src/main/frontend/src/nodes/__test__/selectors.test.js
+++ b/src/main/frontend/src/nodes/__test__/selectors.test.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import {describe, test, expect} from 'vitest';
+import {isMinikube} from '../selectors';
+
+describe('Nodes selectors tests', () => {
+  describe('isMinikube', () => {
+    const minikubeLabels = {
+      'minikube.k8s.io/name': 'minikube',
+      'minikube.k8s.io/version': 'v1.32.0'
+    };
+    const nodesWith = labels => ({
+      'minikube-uid': {
+        metadata: {name: 'minikube', uid: 'minikube-uid', labels}
+      }
+    });
+
+    test('should return true for a single minikube node with the required labels', () => {
+      expect(isMinikube(nodesWith(minikubeLabels))).toBe(true);
+    });
+
+    test('should return true when the version label is present but empty (own-property check, not truthiness)', () => {
+      expect(
+        isMinikube(
+          nodesWith({...minikubeLabels, 'minikube.k8s.io/version': ''})
+        )
+      ).toBe(true);
+    });
+
+    test('should return false when the minikube.k8s.io/version label is absent', () => {
+      expect(isMinikube(nodesWith({'minikube.k8s.io/name': 'minikube'}))).toBe(
+        false
+      );
+    });
+
+    test('should return false when the minikube.k8s.io/name label is not minikube', () => {
+      expect(
+        isMinikube(
+          nodesWith({
+            'minikube.k8s.io/name': 'not-minikube',
+            'minikube.k8s.io/version': 'v1.32.0'
+          })
+        )
+      ).toBe(false);
+    });
+
+    test('should return false when the single node is not named minikube', () => {
+      expect(
+        isMinikube({
+          'node-uid': {
+            metadata: {name: 'node-1', uid: 'node-uid', labels: minikubeLabels}
+          }
+        })
+      ).toBe(false);
+    });
+
+    test('should return false when there is more than one node', () => {
+      expect(
+        isMinikube({
+          'minikube-uid': {
+            metadata: {
+              name: 'minikube',
+              uid: 'minikube-uid',
+              labels: minikubeLabels
+            }
+          },
+          'extra-uid': {
+            metadata: {
+              name: 'minikube',
+              uid: 'extra-uid',
+              labels: minikubeLabels
+            }
+          }
+        })
+      ).toBe(false);
+    });
+
+    test('should return false for an empty node collection', () => {
+      expect(isMinikube({})).toBe(false);
+    });
+  });
+});

--- a/src/main/frontend/src/nodes/selectors.js
+++ b/src/main/frontend/src/nodes/selectors.js
@@ -69,5 +69,5 @@ export const isMinikube = nodes =>
   Object.values(nodes)
     .filter(node => name(node) === 'minikube')
     .filter(node => labels(node)['minikube.k8s.io/name'] === 'minikube')
-    .filter(node => labels(node).hasOwnProperty('minikube.k8s.io/version'))
+    .filter(node => Object.hasOwn(labels(node), 'minikube.k8s.io/version'))
     .length === 1;

--- a/src/main/frontend/src/persistentvolumeclaims/List.jsx
+++ b/src/main/frontend/src/persistentvolumeclaims/List.jsx
@@ -21,7 +21,7 @@ import {Icon, Link, ResourceListV2, Table} from '../components';
 import {api, selectors} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon className='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/persistentvolumes/List.jsx
+++ b/src/main/frontend/src/persistentvolumes/List.jsx
@@ -21,7 +21,7 @@ import {Icon, Link, ResourceListV2, Table} from '../components';
 import {api, selectors} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon className='fa-id-card' /> Name
   </span>,
   'Storage Class',

--- a/src/main/frontend/src/pods/List.jsx
+++ b/src/main/frontend/src/pods/List.jsx
@@ -22,7 +22,7 @@ import {api, selectors, StatusIcon} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/replicasets/List.jsx
+++ b/src/main/frontend/src/replicasets/List.jsx
@@ -22,7 +22,7 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/replicationcontrollers/List.jsx
+++ b/src/main/frontend/src/replicationcontrollers/List.jsx
@@ -22,7 +22,7 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/roles/List.jsx
+++ b/src/main/frontend/src/roles/List.jsx
@@ -27,11 +27,11 @@ import {Icon, Link, Tooltip, Table, ResourceListV2} from '../components';
 import {api} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon className='fa-id-card' /> Name
   </span>,
   'Namespace',
-  <span>
+  <span key='time'>
     <Icon stylePrefix='far' icon='fa-clock' /> Time
   </span>,
   ''

--- a/src/main/frontend/src/routes/List.jsx
+++ b/src/main/frontend/src/routes/List.jsx
@@ -21,7 +21,7 @@ import {Icon, Link, ResourceListV2, Table} from '../components';
 import {Host, api, selectors} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/secrets/List.jsx
+++ b/src/main/frontend/src/secrets/List.jsx
@@ -21,7 +21,7 @@ import {Icon, Link, ResourceListV2, Table} from '../components';
 import {api, selectors} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon className='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/serviceaccounts/List.jsx
+++ b/src/main/frontend/src/serviceaccounts/List.jsx
@@ -29,11 +29,11 @@ import {Age, Icon, Link, ResourceListV2, Table} from '../components';
 import {api} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',
-  <span>
+  <span key='labels'>
     <Icon icon='fa-tags' /> Labels
   </span>,
   'Age',

--- a/src/main/frontend/src/services/List.jsx
+++ b/src/main/frontend/src/services/List.jsx
@@ -21,7 +21,7 @@ import {Icon, Link, ResourceListV2, Table} from '../components';
 import {Type, api, selectors} from './';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon className='fa-id-card' /> Name
   </span>,
   'Namespace',

--- a/src/main/frontend/src/services/PortList.jsx
+++ b/src/main/frontend/src/services/PortList.jsx
@@ -18,7 +18,7 @@ import React from 'react';
 import {Icon, Table} from '../components';
 
 const headers = [
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'App Protocol',

--- a/src/main/frontend/src/statefulsets/List.jsx
+++ b/src/main/frontend/src/statefulsets/List.jsx
@@ -22,11 +22,11 @@ import {api, selectors} from './';
 
 const headers = [
   '',
-  <span>
+  <span key='name'>
     <Icon icon='fa-id-card' /> Name
   </span>,
   'Namespace',
-  <span>
+  <span key='images'>
     <Icon icon='fa-layer-group' /> Images
   </span>,
   ''


### PR DESCRIPTION
## What

Clears all 38 ESLint warnings from `make lint` / the CI build. 0 errors before, but the noise hid regressions and the missing `key` props were a genuine React correctness bug (broken list reconciliation on reorder/update).

## Changes

- **37× `react/jsx-key`** — add a stable, semantic `key` to every header element in the static `headers` arrays across 26 resource `List.jsx` components + `services/PortList.jsx`. Keys derive from the column label (`name`, `images`, `labels`, `roles`, `time`, `scale-target`, `last-seen`), matching the existing convention in `clusterroles`/`clusterrolebindings`/`rolebindings`.
- **1× `no-prototype-builtins`** — `nodes/selectors.js` now uses `Object.hasOwn(labels(node), …)` instead of calling `hasOwnProperty` on the target object.
- **CI guard** — the `eslint` npm script now runs with `--max-warnings=0`, so future warnings fail the build (`prestart`/`prebuild` both invoke it).
- **Test** — adds a black-box Vitest suite for `isMinikube`, including a case that guards the `Object.hasOwn` change (label present-but-empty vs absent).

## Verification

- `make lint` → 0 warnings, 0 errors
- `make fmt-check` / `make license-check` → clean
- `make test-frontend` → 172 passed (13 files)
- `make test-it` (Selenium) → 160 passed, BUILD SUCCESS