### PR TITLE
chore(ci): enable Dependabot and pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /src/main/frontend
+    schedule:
+      interval: weekly
+    versioning-strategy: increase
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check license headers
         run: make license-check
 
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -43,14 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: 'npm'
           cache-dependency-path: src/main/frontend/package-lock.json
       - name: Setup Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -63,9 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: 'npm'
           cache-dependency-path: src/main/frontend/package-lock.json

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,14 +23,14 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: 'npm'
           cache-dependency-path: src/main/frontend/package-lock.json
       - name: Setup Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,14 +20,14 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: 'npm'
           cache-dependency-path: src/main/frontend/package-lock.json
       - name: Setup Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
## What

- Add `.github/dependabot.yml` enabling weekly Dependabot version updates for three ecosystems:
  - `npm` (`/src/main/frontend`) with `versioning-strategy: increase` to keep exact pins
  - `maven` (`/`)
  - `github-actions` (`/`)
- Pin every action across all three workflows to a full commit SHA with a trailing `# vX.Y.Z` comment:
  - `actions/checkout` → `v6.0.3`
  - `actions/setup-node` → `v6.4.0`
  - `actions/setup-java` → `v5.2.0`

## Why

Dependabot version updates were never running (no config file existed), so routine dependency drift across npm, Maven, and GitHub Actions was unmanaged — only repo-level security updates fired. Pinning actions to immutable commit SHAs hardens the supply chain (these workflows hold `packages: write` and registry credentials), and the `# vX.Y.Z` comments let Dependabot keep the SHAs current.

## Verification

Run as the four CI jobs — all green:
- `make license-check` — 447 files, all headers present
- `make test-unit` — 84 tests, 0 failures, 0 errors
- `make test-it` — 160 tests, 0 failures, 0 errors
- `make test-frontend` — 165/165 passed

## Follow-up

Once merged, Dependabot will open the initial catch-up wave of version-update PRs (deps drifted while updates were off); review/merge those and confirm CI stays green.

Refs manusa/com.marcnuri.automated-tasks#1889