### PR TITLE
test: cover untested shared UI hooks in the Selenium IT suite

### DIFF
--- a/src/test/java/com/marcnuri/yakd/configmaps/ConfigMapIT.java
+++ b/src/test/java/com/marcnuri/yakd/configmaps/ConfigMapIT.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,9 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ConfigMapIT extends AbstractResourceIT<ConfigMap> {
 
   private static final String DETAIL_MARKER = "config-map-detail-marker";
-
-  @ConfigProperty(name = SeleniumTestResource.DOWNLOAD_DIRECTORY_PROPERTY)
-  String downloadDirectory;
 
   public ConfigMapIT() {
     super("configmaps");
@@ -191,6 +188,10 @@ public class ConfigMapIT extends AbstractResourceIT<ConfigMap> {
     void downloadWritesYaml() throws Exception {
       downloadFromDetail();
 
+      // Read on demand (not via @ConfigProperty) so this Selenium-only property never becomes a
+      // required config value at the boot of unrelated @QuarkusTest unit tests.
+      final String downloadDirectory = ConfigProvider.getConfig()
+        .getValue(SeleniumTestResource.DOWNLOAD_DIRECTORY_PROPERTY, String.class);
       final Path downloaded = Path.of(downloadDirectory, name + ".yaml");
       await(() -> Files.exists(downloaded));
       assertThat(Files.readString(downloaded))

--- a/src/test/java/com/marcnuri/yakd/configmaps/ConfigMapIT.java
+++ b/src/test/java/com/marcnuri/yakd/configmaps/ConfigMapIT.java
@@ -18,14 +18,19 @@ package com.marcnuri.yakd.configmaps;
 
 import com.marcnuri.yakd.selenium.AbstractResourceIT;
 import com.marcnuri.yakd.selenium.IntegrationTestProfile;
+import com.marcnuri.yakd.selenium.SeleniumTestResource;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,6 +40,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ConfigMapIT extends AbstractResourceIT<ConfigMap> {
 
   private static final String DETAIL_MARKER = "config-map-detail-marker";
+
+  @ConfigProperty(name = SeleniumTestResource.DOWNLOAD_DIRECTORY_PROPERTY)
+  String downloadDirectory;
 
   public ConfigMapIT() {
     super("configmaps");
@@ -136,6 +144,58 @@ public class ConfigMapIT extends AbstractResourceIT<ConfigMap> {
       assertThat(label(name, "mutation-marker"))
         .as("mutation-marker label on the persisted config map")
         .isEqualTo("after-edit");
+    }
+  }
+
+  @Nested
+  @DisplayName("when deleting from the detail page action menu")
+  class DeleteFromDetail {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-delete-detail");
+      openDetail(seededUid(name));
+      // The name only renders once the detail page has loaded the resource, so it gates the action.
+      awaitPageContains(name);
+    }
+
+    @Test
+    @DisplayName("clicking delete removes the config map from the backend")
+    void deleteRemovesResource() {
+      deleteFromDetail();
+
+      await(() -> !exists(name));
+      assertThat(exists(name))
+        .as("config map still present in the backend after detail-page delete")
+        .isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("when downloading from the detail page action menu")
+  class DownloadFromDetail {
+
+    private String name;
+
+    @BeforeEach
+    void navigate() {
+      name = seed("to-download");
+      openDetail(seededUid(name));
+      awaitPageContains(name);
+    }
+
+    @Test
+    @DisplayName("clicking download writes the config map YAML to a file")
+    void downloadWritesYaml() throws Exception {
+      downloadFromDetail();
+
+      final Path downloaded = Path.of(downloadDirectory, name + ".yaml");
+      await(() -> Files.exists(downloaded));
+      assertThat(Files.readString(downloaded))
+        .as("downloaded config map YAML contents")
+        .contains(DETAIL_MARKER);
     }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/customresources/CustomResourceIT.java
+++ b/src/test/java/com/marcnuri/yakd/customresources/CustomResourceIT.java
@@ -174,5 +174,22 @@ public class CustomResourceIT {
         .as("mutation-marker label on the persisted custom resource instance")
         .isEqualTo("after-edit");
     }
+
+    @Test
+    @DisplayName("editing and cancelling discards the change without persisting")
+    void cancelDiscardsChange() {
+      driver.findElement(By.linkText(instanceName)).click();
+      ui.await(() -> ui.editorContains("before-edit"));
+
+      ui.editorReplace("before-edit", "after-edit-cancelled");
+      driver.findElement(By.cssSelector("[data-testid='resource-edit__cancel']")).click();
+      // Cancel unmounts the modal; waiting for it to close proves Cancel fired before we assert
+      // that nothing was persisted.
+      ui.await(() -> driver.findElements(By.cssSelector("[data-testid='resource-edit__cancel']")).isEmpty());
+
+      assertThat(backendMutationMarker())
+        .as("mutation-marker label unchanged after cancelling the edit")
+        .isEqualTo("before-edit");
+    }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/deployment/DeploymentIT.java
+++ b/src/test/java/com/marcnuri/yakd/deployment/DeploymentIT.java
@@ -367,6 +367,23 @@ public class DeploymentIT extends AbstractResourceIT<Deployment> {
         .as("row for the selected-namespace deployment present after filtering")
         .isTrue();
     }
+
+    @Test
+    @DisplayName("clearing the filter with All namespaces restores other-namespace rows")
+    void allNamespacesRestoresRows() {
+      // The @BeforeEach filtered to "default", so the other-namespace deployment is hidden.
+      awaitNoRow(OTHER_DEPLOYMENT_NAME);
+      driver.findElement(By.cssSelector("[data-testid='filter-bar__namespace'] button")).click();
+      final By allNamespaces = By.cssSelector("[data-testid='filter-bar__all-namespaces']");
+      await(() -> !driver.findElements(allNamespaces).isEmpty()
+        && driver.findElement(allNamespaces).isDisplayed());
+      driver.findElement(allNamespaces).click();
+
+      await(() -> hasRow(OTHER_DEPLOYMENT_NAME));
+      assertThat(hasRow(OTHER_DEPLOYMENT_NAME))
+        .as("row for the other-namespace deployment restored after clearing the filter")
+        .isTrue();
+    }
   }
 
   @Nested

--- a/src/test/java/com/marcnuri/yakd/deploymentconfigs/DeploymentConfigIT.java
+++ b/src/test/java/com/marcnuri/yakd/deploymentconfigs/DeploymentConfigIT.java
@@ -211,6 +211,18 @@ public class DeploymentConfigIT extends AbstractResourceIT<DeploymentConfig> {
         .as("spec.replicas on the persisted deployment config")
         .isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("decrementing the replicas persists the new replica count to the backend")
+    void decrementPersistsReplicas() {
+      // The seeded deployment config starts at one replica, so a single decrement scales it to zero.
+      driver.findElement(By.cssSelector("[data-testid='replicas-field__decrement']")).click();
+
+      await(() -> Integer.valueOf(0).equals(backendReplicas(name)));
+      assertThat(backendReplicas(name))
+        .as("spec.replicas on the persisted deployment config")
+        .isEqualTo(0);
+    }
   }
 
   @Nested

--- a/src/test/java/com/marcnuri/yakd/node/NodeIT.java
+++ b/src/test/java/com/marcnuri/yakd/node/NodeIT.java
@@ -189,5 +189,15 @@ public class NodeIT extends AbstractResourceIT<Node> {
         .as("allocatable memory rendered in the node's Memory dial")
         .isTrue();
     }
+
+    @Test
+    @DisplayName("the Memory dial renders the summed requested memory from scheduled pods")
+    void memoryDialShowsRequested() {
+      // 321Mi requested by the scheduled pod, rendered human-readable by the UI.
+      awaitPageContains("321 MiB");
+      assertThat(pageContains("321 MiB"))
+        .as("requested memory rendered in the node's Memory dial")
+        .isTrue();
+    }
   }
 }

--- a/src/test/java/com/marcnuri/yakd/selenium/AbstractResourceIT.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/AbstractResourceIT.java
@@ -113,6 +113,11 @@ public abstract class AbstractResourceIT<T extends HasMetadata> {
     return resource.getMetadata().getName();
   }
 
+  /** Whether a previously {@link #seed(String) seeded} resource still exists on the server. */
+  protected boolean exists(String name) {
+    return fetch(name) != null;
+  }
+
   /** The server-assigned uid of a previously {@link #seed(String) seeded} resource. */
   protected String seededUid(String name) {
     final HasMetadata stored = fetch(name);
@@ -171,6 +176,14 @@ public abstract class AbstractResourceIT<T extends HasMetadata> {
 
   protected void deleteRow(String name) {
     ui.deleteRow(name);
+  }
+
+  protected void deleteFromDetail() {
+    ui.deleteFromDetail();
+  }
+
+  protected void downloadFromDetail() {
+    ui.downloadFromDetail();
   }
 
   protected void awaitRow(String name) {

--- a/src/test/java/com/marcnuri/yakd/selenium/ResourceUi.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/ResourceUi.java
@@ -42,6 +42,9 @@ public class ResourceUi {
   private static final By ROW = By.cssSelector("[data-testid='resource-list__row']");
   private static final By ROW_DELETE = By.cssSelector("[data-testid='resource-list__delete']");
   private static final By EDIT_SAVE = By.cssSelector("[data-testid='resource-edit__save']");
+  private static final By POPUP_TRIGGER = By.cssSelector("[data-testid='popup-menu__trigger']");
+  private static final By DETAIL_DELETE = By.cssSelector("[data-testid='resource-detail__delete']");
+  private static final By DETAIL_DOWNLOAD = By.cssSelector("[data-testid='resource-detail__download']");
 
   private final WebDriver driver;
   private final URL url;
@@ -124,6 +127,26 @@ public class ResourceUi {
 
   public boolean pageContains(String text) {
     return driver.getPageSource().contains(text);
+  }
+
+  /**
+   * Opens the detail-page action menu and clicks its Delete item. The menu items are in the DOM but
+   * CSS-hidden until the trigger is clicked, so this opens the popup and waits for the item to be
+   * visible before clicking it.
+   */
+  public void deleteFromDetail() {
+    clickDetailMenuItem(DETAIL_DELETE);
+  }
+
+  /** Opens the detail-page action menu and clicks its Download item. See {@link #deleteFromDetail()}. */
+  public void downloadFromDetail() {
+    clickDetailMenuItem(DETAIL_DOWNLOAD);
+  }
+
+  private void clickDetailMenuItem(By item) {
+    driver.findElement(POPUP_TRIGGER).click();
+    await(() -> !driver.findElements(item).isEmpty() && driver.findElement(item).isDisplayed());
+    driver.findElement(item).click();
   }
 
   // --- YAML editor ---

--- a/src/test/java/com/marcnuri/yakd/selenium/SeleniumTestResource.java
+++ b/src/test/java/com/marcnuri/yakd/selenium/SeleniumTestResource.java
@@ -23,15 +23,25 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 
+import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class SeleniumTestResource implements QuarkusTestResourceConfigurableLifecycleManager<WithSelenium> {
+
+  // Exposes the browser's download directory to tests (e.g. the detail-page Download action) as a
+  // config property so they can read the file Chrome writes there.
+  public static final String DOWNLOAD_DIRECTORY_PROPERTY = "yakd.it.download-directory";
 
   private boolean headless;
   private ChromeDriverService chromeDriverService;
   private ChromeDriver chromeDriver;
+  private Path downloadDirectory;
 
   @Override
   public void init(WithSelenium annotation) {
@@ -48,12 +58,21 @@ public class SeleniumTestResource implements QuarkusTestResourceConfigurableLife
     } catch (IOException exception) {
       throw new IllegalStateException("Unable to start ChromeDriverService", exception);
     }
+    try {
+      downloadDirectory = Files.createTempDirectory("yakd-it-downloads");
+    } catch (IOException exception) {
+      throw new IllegalStateException("Unable to create the browser download directory", exception);
+    }
     final ChromeOptions chromeOptions = new ChromeOptions();
     if (headless) {
       chromeOptions.addArguments("--headless=new");
     }
+    final Map<String, Object> preferences = new HashMap<>();
+    preferences.put("download.default_directory", downloadDirectory.toString());
+    preferences.put("download.prompt_for_download", false);
+    chromeOptions.setExperimentalOption("prefs", preferences);
     chromeDriver = new ChromeDriver(chromeDriverService, chromeOptions);
-    return Collections.emptyMap();
+    return Map.of(DOWNLOAD_DIRECTORY_PROPERTY, downloadDirectory.toString());
   }
 
   @Override
@@ -63,6 +82,14 @@ public class SeleniumTestResource implements QuarkusTestResourceConfigurableLife
     }
     if (chromeDriverService != null) {
       chromeDriverService.stop();
+    }
+    if (downloadDirectory != null) {
+      // Best-effort cleanup of the temp download directory and anything the browser wrote there.
+      try (Stream<Path> paths = Files.walk(downloadDirectory)) {
+        paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+      } catch (IOException ignored) {
+        // Test-only temp directory; leave it for the OS to reap if cleanup fails.
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Continuation of #205. An audit of the Selenium IT suite surfaced shared
`data-testid` hooks documented in `CLAUDE.md` that no integration test
exercised. This adds a behavioral IT for each, on one representative
resource (the hooks belong to shared components, so covering them once
exercises every caller), plus the listed Node Memory-dial follow-up.

## New coverage

| Behavior | data-testid | Test |
|---|---|---|
| Delete from the detail-page action menu | `resource-detail__delete` | `ConfigMapIT` |
| Download resource YAML from the detail page | `resource-detail__download` | `ConfigMapIT` |
| Scale **down** caret persists the new count | `replicas-field__decrement` | `DeploymentConfigIT` |
| Editor **Cancel** discards without persisting | `resource-edit__cancel` | `CustomResourceIT` |
| Clearing the namespace filter restores rows | `filter-bar__all-namespaces` | `DeploymentIT` |
| Node Memory dial renders requested memory (`321 MiB`) | — | `NodeIT` (#205 follow-up) |

## Supporting changes

- `ResourceUi` / `AbstractResourceIT`: shared `deleteFromDetail()`,
  `downloadFromDetail()` and `exists()` helpers. The popup-menu actions
  open the menu and click the item once it is visible.
- `SeleniumTestResource`: configure a temporary Chrome download directory
  and expose it as the `yakd.it.download-directory` config property so the
  download action can be verified black-box; the directory is cleaned up
  on `stop()`.

## Testing

`make test-it IT=ConfigMapIT,NodeIT,CustomResourceIT,DeploymentIT,DeploymentConfigIT`
→ BUILD SUCCESS, 40 tests, 0 failures. Black-box only, one assertion per test.

Closes #205