### PR TITLE
chore(deps): update Java to 25 LTS

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -29,10 +29,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Setup Java 21
+      - name: Setup Java 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
       - name: Run unit tests
@@ -49,10 +49,10 @@ jobs:
         with:
           cache: 'npm'
           cache-dependency-path: src/main/frontend/package-lock.json
-      - name: Setup Java 21
+      - name: Setup Java 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
       - name: Run integration tests

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           cache: 'npm'
           cache-dependency-path: src/main/frontend/package-lock.json
-      - name: Setup Java 21
+      - name: Setup Java 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
       - name: Package

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           cache: 'npm'
           cache-dependency-path: src/main/frontend/package-lock.json
-      - name: Setup Java 21
+      - name: Setup Java 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
       - name: Package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # YAKD — AI Agents Instructions
 
-YAKD (Yet Another Kubernetes Dashboard) is a Quarkus (Java 21) + React web UI for Kubernetes and OpenShift clusters. Frontend lives under `src/main/frontend/`, gets built into the backend JAR under `frontend/` (see `pom.xml:120-123`). This file documents what an old hand would tell a new contributor on day one — read this first; fall back to grep only when something here doesn't match what you see.
+YAKD (Yet Another Kubernetes Dashboard) is a Quarkus (Java 25) + React web UI for Kubernetes and OpenShift clusters. Frontend lives under `src/main/frontend/`, gets built into the backend JAR under `frontend/` (see `pom.xml:120-123`). This file documents what an old hand would tell a new contributor on day one — read this first; fall back to grep only when something here doesn't match what you see.
 
 ## Canonical commands
 
@@ -54,7 +54,7 @@ Barrel conventions:
 
 ## Code style
 
-**Java.** Java 21. Apache 2.0 header required on every source file (the license-check script gates this; see Gotchas).
+**Java.** Java 25. Apache 2.0 header required on every source file (the license-check script gates this; see Gotchas).
 
 **JavaScript/React.**
 - Prettier config (in `package.json:70-77`): `singleQuote`, `jsxSingleQuote`, `arrowParens: avoid`, `bracketSpacing: false`, `trailingComma: none`. `make fmt` runs it (mutating — see Gotchas).
@@ -213,7 +213,7 @@ docker run --rm --cpus=2 \
   -v "$HOME/.m2":/m2 \
   -v /tmp/flake-logs:/logs \
   --user "$(id -u):$(id -g)" --entrypoint bash \
-  maven:3.9.9-eclipse-temurin-21 -c '
+  maven:3.9.16-eclipse-temurin-25 -c '
     for i in $(seq 1 50); do
       mvn -o -s /m2/settings.xml -Dmaven.repo.local=/m2/repository \
         clean test -Dtest=PodExecEndpointTest -Dquarkus.build.skip=true > /logs/run-$i.log 2>&1 \

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,7 @@
   <name>YAKD :: Application</name>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.release>25</maven.compiler.release>
     <version.quarkus>3.36.2</version.quarkus>
     <version.jkube>1.16.2</version.jkube>
     <version.assertj>3.27.7</version.assertj>

--- a/src/main/docker/Dockerfile.build
+++ b/src/main/docker/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.1-java21 AS build
+FROM quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:jdk-25 AS build
 
 ARG VERSION=snapshot
 
@@ -11,7 +11,7 @@ WORKDIR /project
 RUN ./mvnw -Drevision=${VERSION} -Pnative package
 
 
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
 
 LABEL maintainer="Marc Nuri <marc@marcnuri.com>"
 LABEL org.opencontainers.image.source="https://github.com/manusa/yakd"


### PR DESCRIPTION
## Summary

Updates the project's Java toolchain from 21 to 25 LTS. Closes #170.

## Changes

- **`pom.xml`** — consolidate `maven.compiler.source`/`target` into a single `maven.compiler.release=25`.
- **`src/main/docker/Dockerfile.build`** — move the native-image build to the UBI10 Mandrel `jdk-25` builder (`ubi10-quarkus-mandrel-builder-image:jdk-25`) and the matching `ubi10-quarkus-micro-image:2.0` runtime (UBI version kept aligned for glibc compatibility).
- **CI workflows** (`build-and-test.yaml`, `publish-snapshot.yml`, `publish-release.yml`) — bump `actions/setup-java` to Temurin `25`.
- **`AGENTS.md`** — update Java version references.

## Verification

Run under Temurin 25.0.3:

- `make test-unit` — 84 passed
- `make test-it` — 166 passed (Selenium IT)
- `make test-frontend` — 172 passed (Vitest)
- `make license-check` — clean
- **Native image** — `docker build` on UBI10 (Mandrel 25.0.3 / JDK 25.0.3) succeeds; the resulting 197 MB image boots in ~0.02s and serves HTTP 200 (`/` and `/q/health`).